### PR TITLE
APICLI-1323: Create Function to Surface IP Address for Droplets

### DIFF
--- a/do-client-python/digitalocean/operations/_patch.py
+++ b/do-client-python/digitalocean/operations/_patch.py
@@ -6,13 +6,20 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
-from typing import TYPE_CHECKING
+from typing import List
+from ._operations import DropletsOperations as Droplets
 
-if TYPE_CHECKING:
-    # pylint: disable=unused-import,ungrouped-imports
-    from typing import List
+class DropletsOperations(Droplets):
 
-__all__ = []  # type: List[str]  # Add all objects you want publicly available to users at this package level
+    @classmethod
+    def get_public_IPv4(self, droplet):
+        ip_address = ''
+        for net in droplet['networks']['v4']:
+            if net['type'] == 'public':
+                ip_address = net['ip_address']
+        return ip_address
+
+__all__ = ["DropletsOperations"]
 
 def patch_sdk():
     """Do not remove from this file.


### PR DESCRIPTION
Allows one to get the IP address of a droplet using the following code:

```
            get_resp = self.client.droplets.get(droplet_id)
            droplet = get_resp['droplet']
            ip_address = self.client.droplets.get_public_IPv4(droplet=droplet)
```