### PR TITLE
Add pyproject.toml for testing local builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,9 @@
 # Python
 __pycache__/
 *.pyc
+build
+dist
+digitalocean.egg-info
 
 # client gen
 DigitalOcean-public.v2.yaml
-
-node_modules/*

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "digitalocean"
+version = "0.1.0"
+description = "The official client for interacting with the DigitalOcean API"
+readme = "README.md"
+requires-python = ">=3.9"
+
+authors = [
+    {name = "API Engineering"},
+    {email = "<api-engineering@digitalocean.com>"}
+]
+
+dependencies = [
+    "azure-core>=1.24.0",
+    "azure-identity>=1.5.0",
+    "isodate>=0.6.1",
+    "msrest>=0.7.1",
+    "typing-extensions>=3.7.4"
+]
+
+[project.urls]
+repository = "https://github.com/digitalocean/digitalocean-client-python"


### PR DESCRIPTION
The pyproject.toml allows us to maintain the dependencies of the package. 

For now, this will enable devs to test local builds of the package, as well as help set up environments for a test suite. 
In the future, this will help when we're ready to publish the package. 