### PR TITLE
Use GITHUB_TOKEN in workflow.

### DIFF
--- a/.github/workflows/python-client-gen.yml
+++ b/.github/workflows/python-client-gen.yml
@@ -25,7 +25,7 @@ jobs:
       id: cpr
       uses: peter-evans/create-pull-request@v4
       with:
-        token: ${{ secrets.PY_CLIENT }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Re-generate Python Client
         committer: GitHub <noreply@github.com>
         author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>


### PR DESCRIPTION
Currently the action fails on the step for opening a PR:

```
fatal: could not read Username for 'https://github.com': No such device or address
Error: The process '/usr/bin/git' failed with exit code 128
```

https://github.com/digitalocean/digitalocean-client-python/runs/7221459241?check_suite_focus=true#step:7:47

According to https://github.com/peter-evans/create-pull-request/issues/651, that error suggests that the provided token does not have access to the repository. The builtin `GITHUB_TOKEN` one should have the permissions we need.