### PR TITLE
Remove get_public_IPv4 DropletsOperations patch

### DIFF
--- a/src/digitalocean/operations/_patch.py
+++ b/src/digitalocean/operations/_patch.py
@@ -15,18 +15,7 @@ if TYPE_CHECKING:
     pass
 
 
-class DropletsOperations(Droplets):
-    def get_public_IPv4(self, droplet_id: int):
-        droplet = self.get(droplet_id)
-
-        ip_address = ""
-        for net in droplet["networks"]["v4"]:
-            if net["type"] == "public":
-                ip_address = net["ip_address"]
-        return ip_address
-
-
-__all__ = ["DropletsOperations"]
+__all__ = []
 
 
 def patch_sdk():


### PR DESCRIPTION
Methods patched on to the DropletsOperations suggest they offer additional API request functionality. 
The `get_public_IPv4` looks like a helper to quickly get the public IP of a droplet (rather the droplet data that's already been fetched). This takes a droplet object and doesn't perform an API operation so this can be a bit misleading here.

I think this method would make more sense to be patched on the Droplet model as that would represent data that's already been fetched.
Since models aren't currently being generated by our configuration, I think we should remove this for now to avoid confusion.