### PR TITLE
Use default strategy for automated PRs.

### DIFF
--- a/.github/workflows/python-client-gen.yml
+++ b/.github/workflows/python-client-gen.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       commit_url:
         description: 'The commit URL that triggered the workflow'
-        required: true 
+        required: true
         type: string
 jobs:
   Generate-Python-Client:
@@ -30,7 +30,6 @@ jobs:
         committer: GitHub <noreply@github.com>
         author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
         branch: bot-regenerate-python-client
-        branch-suffix: short-commit-hash
         delete-branch: true
         title: '[Bot] Re-generate Python Client'
         body: |


### PR DESCRIPTION
Reading additional details about how this action operates, I think we should remove the `branch-suffix` setting. This causes the branch used for the PR to be suffixed with the short SHA1 commit hash of the most recent commit in `main` when the PR is created, e.g.  `bot-regenerate-python-client-b027398`. This will lead to new PRs being opened if main gains additional changes between OpenAPI changes. By default, using a stable branch identifier, any existing PR will be updated instead.

For more detail, see: https://github.com/peter-evans/create-pull-request#action-behaviour