### PR TITLE
Remove get_public_IPv4 from class methods test.

### DIFF
--- a/tests/mocked/test_client_class_methods.py
+++ b/tests/mocked/test_client_class_methods.py
@@ -198,7 +198,7 @@ def test_class_names(client_resources):
                 "list_snapshots",
                 "list_associated_resources",
             },
-            {"get_public_IPv4"},
+            {},
         ),
         (
             "firewalls",


### PR DESCRIPTION
The mocked tests are failing since the removal of the `get_public_IPv4` `DropletsOperations` patch in https://github.com/digitalocean/digitalocean-client-python/pull/16