### PR TITLE
make lint-tests: add diff flag to black call.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ download-spec: ## Download Latest DO Spec
 ifndef SPEC_FILE
 generate: SPEC_FILE = $(LOCAL_SPEC_FILE)
 generate: dev-dependencies download-spec ## Generates the python client using the latest published spec first.
-endif 
+endif
 generate: clean dev-dependencies
 	@printf "=== Generating client with spec: $(SPEC_FILE)\n\n"; \
 	npm run autorest -- client_gen_config.md \
@@ -46,7 +46,7 @@ endif
 
 .PHONY: lint-tests
 lint-tests: install
-	poetry run black --check tests/. && \
+	poetry run black --check --diff tests/. && \
 	poetry run pylint $(PYLINT_ARGS) tests/.
 
 .PHONY: test-mocked


### PR DESCRIPTION
Without the diff flag, the error just says a file would be reformatted, e.g.:

```
$ poetry run black --check tests/.
would reformat tests/mocked/test_tags.py

Oh no! 💥 💔 💥
1 file would be reformatted, 13 files would be left unchanged.
```

The output would be more helpful, especially in CI, with the diff flag:

```
$ poetry run black --check --diff tests/.
--- tests/mocked/test_tags.py   2022-07-11 17:10:08.903167 +0000
+++ tests/mocked/test_tags.py   2022-07-11 17:10:14.619776 +0000
@@ -95,9 +95,10 @@
 
     responses.add(
         responses.POST,
         f"{mock_client_url}/v2/tags",
         json=expected,
-        status=201,)
+        status=201,
+    )
     tags = mock_client.tags.create(body={"name": "foo"})
 
     assert tags == expected
would reformat tests/mocked/test_tags.py

Oh no! 💥 💔 💥
1 file would be reformatted, 13 files would be left unchanged.
```