### PR TITLE
pyproject: Allow all supported Python versions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["API Engineering <api-engineering@digitalocean.com>"]
 license = "Apache"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.7"
 azure-core = ">=1.24.0"
 azure-identity = ">=1.5.0"
 isodate = ">=0.6.1"


### PR DESCRIPTION
We should allow installing with all supported Python versions. Ubuntu 20.04 which is a LTS and will be support for a long time to come still has 3.8 by default. 3.7 is oldest still supported: https://devguide.python.org/#status-of-python-branches