### PR TITLE
Simplify the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-LOCAL_SPEC_FILE=./DigitalOcean-public.v2.yaml
+SPEC_FILE?=https://api-engineering.nyc3.digitaloceanspaces.com/spec-ci/DigitalOcean-public.v2.yaml
 MODELERFOUR_VERSION="4.23.6"
 AUTOREST_PYTHON_VERSION="6.0.1"
 PACKAGE_VERSION?="dev"
@@ -17,18 +17,8 @@ clean: ## Removes all generated code (except _patch.py files)
 	@printf "=== Cleaning src directory\n"
 	@find src/digitalocean -type f ! -name "_patch.py" ! -name "custom_*.py" -exec rm -rf {} +
 
-.PHONY: download-spec
-download-spec: ## Download Latest DO Spec
-	@echo Downloading published spec; \
-	touch DigitalOcean-public.v2.yaml && \
-	curl https://api-engineering.nyc3.digitaloceanspaces.com/spec-ci/DigitalOcean-public.v2.yaml -o $(LOCAL_SPEC_FILE)
-
 .PHONY: generate
-ifndef SPEC_FILE
-generate: SPEC_FILE = $(LOCAL_SPEC_FILE)
-generate: dev-dependencies download-spec ## Generates the python client using the latest published spec first.
-endif
-generate: clean dev-dependencies
+generate: clean dev-dependencies ## Generates the python client using the latest published spec first.
 	@printf "=== Generating client with spec: $(SPEC_FILE)\n\n"; \
 	npm run autorest -- client_gen_config.md \
 		--use:@autorest/modelerfour@$(MODELERFOUR_VERSION) \


### PR DESCRIPTION
It looks like `autorest` supports using a url for the spec path, so we don't have to download it.
This change still supports overwriting `SPEC_PATH` with a local file to generate from local `openapi` changes.