### PR TITLE
Pin autorest more strictly.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,31 @@
       "name": "@digitalocean/digitalocean-client-python",
       "license": "Apache-2.0",
       "devDependencies": {
-        "autorest": "^3.6.1"
+        "@autorest/core": "~3.9.0",
+        "@autorest/modelerfour": "~4.23.6",
+        "autorest": "~3.6.1"
+      }
+    },
+    "node_modules/@autorest/core": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@autorest/core/-/core-3.9.0.tgz",
+      "integrity": "sha512-qLpoSQVwrapzwTXNq/QnWiOZstuNowYdYIKmE5tYwiREvitfi/9dNE3GDEQwo6ailQIkw7EV3W5aWFuxGDo5Xw==",
+      "dev": true,
+      "bin": {
+        "autorest-core": "entrypoints/app.js",
+        "autorest-language-service": "entrypoints/language-service.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@autorest/modelerfour": {
+      "version": "4.23.7",
+      "resolved": "https://registry.npmjs.org/@autorest/modelerfour/-/modelerfour-4.23.7.tgz",
+      "integrity": "sha512-BVjzDd12LvYSkI20WTUgz4RPPPCYtewaWbYmcztltJzRtRe8T9dbaXjM1bySysI8feJSIpgAja2e+lhyKDKX+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/autorest": {
@@ -25,6 +49,18 @@
     }
   },
   "dependencies": {
+    "@autorest/core": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@autorest/core/-/core-3.9.0.tgz",
+      "integrity": "sha512-qLpoSQVwrapzwTXNq/QnWiOZstuNowYdYIKmE5tYwiREvitfi/9dNE3GDEQwo6ailQIkw7EV3W5aWFuxGDo5Xw==",
+      "dev": true
+    },
+    "@autorest/modelerfour": {
+      "version": "4.23.7",
+      "resolved": "https://registry.npmjs.org/@autorest/modelerfour/-/modelerfour-4.23.7.tgz",
+      "integrity": "sha512-BVjzDd12LvYSkI20WTUgz4RPPPCYtewaWbYmcztltJzRtRe8T9dbaXjM1bySysI8feJSIpgAja2e+lhyKDKX+w==",
+      "dev": true
+    },
     "autorest": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/autorest/-/autorest-3.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "@digitalocean/digitalocean-client-python",
   "description": "Python client generator based on DigitalOcean's OpenAPI specification.",
   "devDependencies": {
-    "autorest": "^3.6.1"
+    "autorest": "~3.6.1",
+    "@autorest/core": "~3.9.0",
+    "@autorest/modelerfour": "~4.23.6"
   },
   "scripts": {
     "autorest": "autorest"


### PR DESCRIPTION
In https://github.com/digitalocean/digitalocean-client-python/pull/40, we saw the autorest version change in the file headers:

```diff
- # Code generated by Microsoft (R) AutoRest Code Generator (autorest: 3.8.4, generator: @autorest/python@6.0.1)
+ # Code generated by Microsoft (R) AutoRest Code Generator (autorest: 3.9.0, generator: @autorest/python@6.0.1)
```

Turns out that version number is from `@autorest/core` not `autorest` itself. This PR pins `@autorest/core` and `@autorest/modelerfour` as they are core to the project. It also switches from `^` (minor versions) to `~` (patch versions).