### PR TITLE
Register real_billing marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,8 @@ max-line-length=88 # matches black's default
 
 [tool.pylint.messages_control]
 disable = "no-name-in-module"
+
+[tool.pytest.ini_options]
+markers = [
+    "real_billing: Indicates the test requires a real billing account to test"
+]


### PR DESCRIPTION
We marked the billing integration tests with the `real_billing` marker but also need to register the mark in the pytest config. This adds the config to the pyproject.toml.