### PR TITLE
PR workflow: Always run tests due to required checks.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,12 +2,6 @@ name: pr
 
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'archive/**'
-      - 'examples/**'
-      - '.gitignore'
-      - 'LICENSE'
 
 jobs:
   lint:


### PR DESCRIPTION
Unfortunately, using `paths-ignore` doesn't seem to play well with using required checks on PRs. These will wait indefinitely for PRs like the one above only touching examples, etc. E.g.

https://github.com/digitalocean/digitalocean-client-python/pull/72
https://github.com/digitalocean/digitalocean-client-python/pull/81