### PR TITLE
Functions in aio's patch file must be async

### DIFF
--- a/src/digitalocean/aio/_patch.py
+++ b/src/digitalocean/aio/_patch.py
@@ -27,7 +27,7 @@ class TokenCredentials:
         self._token = token
         self._expires_on = 0
 
-    def get_token(self, *args, **kwargs) -> AccessToken:
+    async def get_token(self, *args, **kwargs) -> AccessToken:
         return AccessToken(self._token, expires_on=self._expires_on)
 
 


### PR DESCRIPTION
```
>>> import asyncio
>>> import os
>>> from digitalocean.aio import Client
>>> client = Client(token=os.getenv('DO_TOKEN'))
>>> async def main():
...     droplets = await client.droplets.list()
...     return droplets
... 
>>> asyncio.run(main())
```

Before this change, this code errors with:

```
  File "/home/asb/.local/lib/python3.8/site-packages/azure/core/pipeline/policies/_authentication_async.py", line 51, in on_request
    self._token = await self._credential.get_token(*self._scopes)
TypeError: object AccessToken can't be used in 'await' expression
```

It works as expected with the change.

