### PR TITLE
Add some basic testing of the aio client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ generate: clean dev-dependencies
 .PHONY: install
 install: ## Install test dependencies
 ifneq (, $(shell which poetry))
-	poetry install --no-interaction
+	poetry install --no-interaction -E aio
 else
 	@(echo "poetry is not installed. See https://python-poetry.org/docs/#installation for more info."; exit 1)
 endif
@@ -65,7 +65,7 @@ test-integration: install
 # > make test-integration-single test=test_actions
 .PHONY: test-mocked
 test-integration-single: install
-	poetry run pytest -rA --tb=short tests/integration/. -k $(test) 
+	poetry run pytest -rA --tb=short tests/integration/. -k $(test)
 
 .PHONY: docker-build
 docker-build:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3,7 +3,7 @@ name = "aiohttp"
 version = "3.8.1"
 description = "Async http client/server framework (asyncio)"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -21,11 +21,22 @@ yarl = ">=1.0,<2.0"
 speedups = ["aiodns", "brotli", "cchardet"]
 
 [[package]]
+name = "aioresponses"
+version = "0.7.3"
+description = "Mock out requests made by ClientSession from aiohttp package"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+aiohttp = ">=2.0.0,<4.0.0"
+
+[[package]]
 name = "aiosignal"
 version = "1.2.0"
 description = "aiosignal: a list of registered asynchronous callbacks"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -33,24 +44,27 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "astroid"
-version = "2.11.7"
+version = "2.12.9"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
-python-versions = ">=3.6.2"
+python-versions = ">=3.7.2"
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0"
 typed-ast = {version = ">=1.4.0,<2.0", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
 typing-extensions = {version = ">=3.10", markers = "python_version < \"3.10\""}
-wrapt = ">=1.11,<2"
+wrapt = [
+    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
+    {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
+]
 
 [[package]]
 name = "async-timeout"
 version = "4.0.2"
 description = "Timeout context manager for asyncio programs"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -61,38 +75,30 @@ name = "asynctest"
 version = "0.13.0"
 description = "Enhance the standard unittest package with features for testing asyncio libraries"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [[package]]
-name = "atomicwrites"
-version = "1.4.1"
-description = "Atomic file writes."
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
 name = "attrs"
-version = "21.4.0"
+version = "22.1.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "azure-core"
-version = "1.24.2"
+version = "1.25.1"
 description = "Microsoft Azure Core Library for Python"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 requests = ">=2.18.4"
@@ -116,7 +122,7 @@ six = ">=1.12.0"
 
 [[package]]
 name = "black"
-version = "22.6.0"
+version = "22.8.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -139,7 +145,7 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2022.6.15"
+version = "2022.9.14"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -158,7 +164,7 @@ pycparser = "*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.1.0"
+version = "2.1.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -189,7 +195,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "cryptography"
-version = "37.0.4"
+version = "38.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -202,7 +208,7 @@ cffi = ">=1.12"
 docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
 docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
-sdist = ["setuptools_rust (>=0.11.4)"]
+sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
 test = ["pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
@@ -222,12 +228,12 @@ name = "frozenlist"
 version = "1.3.1"
 description = "A list-like structure which implements collections.abc.MutableSequence"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [[package]]
 name = "idna"
-version = "3.3"
+version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -350,7 +356,7 @@ name = "multidict"
 version = "6.0.2"
 description = "multidict implementation"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [[package]]
@@ -363,7 +369,7 @@ python-versions = "*"
 
 [[package]]
 name = "oauthlib"
-version = "3.2.0"
+version = "3.2.1"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 category = "main"
 optional = false
@@ -387,11 +393,11 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pathspec"
-version = "0.9.0"
+version = "0.10.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
@@ -471,14 +477,14 @@ tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
 
 [[package]]
 name = "pylint"
-version = "2.14.5"
+version = "2.15.2"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 
 [package.dependencies]
-astroid = ">=2.11.6,<=2.12.0-dev0"
+astroid = ">=2.12.9,<=2.14.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = ">=0.2"
 isort = ">=4.2.5,<6"
@@ -505,14 +511,13 @@ diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pytest"
-version = "7.1.2"
+version = "7.1.3"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
@@ -524,6 +529,21 @@ tomli = ">=1.0.0"
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.19.0"
+description = "Pytest support for asyncio"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=6.1.0"
+typing-extensions = {version = ">=3.7.2", markers = "python_version < \"3.8\""}
+
+[package.extras]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
 name = "pywin32"
@@ -600,7 +620,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "tomlkit"
-version = "0.11.1"
+version = "0.11.4"
 description = "Style preserving TOML library"
 category = "dev"
 optional = false
@@ -624,7 +644,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.10"
+version = "1.26.12"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -632,7 +652,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, 
 
 [package.extras]
 brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -648,7 +668,7 @@ name = "yarl"
 version = "1.8.1"
 description = "Yet another URL library"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -668,18 +688,21 @@ python-versions = ">=3.7"
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
+[extras]
+aio = ["aiohttp"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.2"
-content-hash = "83abff47dadf6103bcd6c5b19ad2e2cf1f3874cca79fc14b0e521b0b2b2cdc1e"
+content-hash = "f58a4b89b253efa8599664dbe1b1a4ecb6aebb9e1ca79d0314183312b73207b2"
 
 [metadata.files]
 aiohttp = []
+aioresponses = []
 aiosignal = []
 astroid = []
 async-timeout = []
 asynctest = []
-atomicwrites = []
 attrs = []
 azure-core = []
 azure-identity = []
@@ -716,6 +739,7 @@ pyjwt = []
 pylint = []
 pyparsing = []
 pytest = []
+pytest-asyncio = []
 pywin32 = []
 requests = []
 requests-oauthlib = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ black = "^22.6.0"
 pylint = "^2.14.4"
 pytest = "^7.1.2"
 responses = "^0.21.0"
+pytest-asyncio = "^0.19.0"
+aioresponses = "^0.7.3"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -34,3 +36,6 @@ disable = "no-name-in-module"
 markers = [
     "real_billing: Indicates the test requires a real billing account to test"
 ]
+
+[tool.poetry.extras]
+aio = ["aiohttp"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,7 @@ from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 from digitalocean import Client
+from digitalocean.aio import Client as aioClient
 
 
 @pytest.fixture(scope="session")
@@ -28,6 +29,26 @@ def integration_client() -> Client:
         pytest.fail("Expected environment variable DO_TOKEN")
 
     client = Client(token)
+    return client
+
+
+@pytest.fixture(scope="session")
+def async_integration_client() -> aioClient:
+    """Instantiates a DigitalOceanClient for use with integration tests.
+
+    The client requires the environment variable DO_TOKEN with a valid API
+    token.
+
+    *IMPORTANT*: Use of this client will create real resources on the
+    account.
+    """
+
+    token = environ.get("DO_TOKEN", None)
+
+    if token is None:
+        pytest.fail("Expected environment variable DO_TOKEN")
+
+    client = aioClient(token)
     return client
 
 

--- a/tests/integration/test_sizes.py
+++ b/tests/integration/test_sizes.py
@@ -1,12 +1,22 @@
 """ test_sizes.py
     Integration Test for Sizes
 """
+import pytest
 
 from digitalocean import Client
+from digitalocean.aio import Client as aioClient
 
 
 def test_sizes_list(integration_client: Client):
     """Testing the List of the Sizes endpoint"""
     list_resp = integration_client.sizes.list()
+
+    assert len(list_resp["sizes"]) >= 20
+
+
+@pytest.mark.asyncio
+async def test_sizes_list_async(async_integration_client: aioClient):
+    """Testing the List of the Sizes endpoint"""
+    list_resp = await async_integration_client.sizes.list()
 
     assert len(list_resp["sizes"]) >= 20

--- a/tests/mocked/conftest.py
+++ b/tests/mocked/conftest.py
@@ -3,6 +3,7 @@
 import pytest
 
 from digitalocean import Client
+from digitalocean.aio import Client as aioClient
 
 
 @pytest.fixture(scope="module")
@@ -17,3 +18,11 @@ def mock_client(mock_client_url) -> Client:
     The mock client doesn't use a valid token and has a fake API endpoint set.
     """
     return Client("", endpoint=mock_client_url)
+
+
+@pytest.fixture(scope="module")
+def mock_aio_client(mock_client_url) -> aioClient:
+    """Initializes a mock aio client
+    The mock client doesn't use a valid token and has a fake API endpoint set.
+    """
+    return aioClient("", endpoint=mock_client_url)

--- a/tests/mocked/test_account.py
+++ b/tests/mocked/test_account.py
@@ -1,28 +1,46 @@
 """Mock tests for the account API resource."""
+import pytest
 import responses
+from aioresponses import aioresponses
 
 from digitalocean import Client
+from digitalocean.aio import Client as aioClient
+
+EXPECTED_ACCOUNT = {
+    "account": {
+        "droplet_limit": 25,
+        "floating_ip_limit": 5,
+        "email": "sammy@digitalocean.com",
+        "uuid": "b6fr89dbf6d9156cace5f3c78dc9851d957381ef",
+        "email_verified": True,
+        "status": "active",
+        "status_message": " ",
+        "team": {
+            "uuid": "5df3e3004a17e242b7c20ca6c9fc25b701a47ece",
+            "name": "My Team",
+        },
+    }
+}
 
 
 @responses.activate
-def test_get(mock_client: Client, mock_client_url):
+def test_account_get(mock_client: Client, mock_client_url):
     """Mocks the account get operation."""
-    expected = {
-        "account": {
-            "droplet_limit": 25,
-            "floating_ip_limit": 5,
-            "email": "sammy@digitalocean.com",
-            "uuid": "b6fr89dbf6d9156cace5f3c78dc9851d957381ef",
-            "email_verified": True,
-            "status": "active",
-            "status_message": " ",
-            "team": {
-                "uuid": "5df3e3004a17e242b7c20ca6c9fc25b701a47ece",
-                "name": "My Team",
-            },
-        }
-    }
-    responses.add(responses.GET, f"{mock_client_url}/v2/account", json=expected)
+
+    responses.add(responses.GET, f"{mock_client_url}/v2/account", json=EXPECTED_ACCOUNT)
     acct = mock_client.account.get()
 
-    assert acct == expected
+    assert acct == EXPECTED_ACCOUNT
+
+
+@pytest.mark.asyncio
+async def test_account_get_async(mock_aio_client: aioClient, mock_client_url):
+    """Mocks the account get aio operation."""
+
+    with aioresponses() as mock_resp:
+        mock_resp.get(
+            f"{mock_client_url}/v2/account", status=200, payload=EXPECTED_ACCOUNT
+        )
+        acct = await mock_aio_client.account.get()
+
+        assert acct == EXPECTED_ACCOUNT


### PR DESCRIPTION
This PR adds some basic testing of the aio client in both the mocked and integrations tests to ensure that it is not broken.

I explored a few ways of reusing the existing tests unchanged with both clients, but I haven't found a way to overcome the basic need for the `async` and `await` keywords. Littering `async` everywhere doesn't seem to impact non-async negatively, but using`await` with the normal client fails. In theory, we could wrap every call in an if/else, and we might want to pursue that latter Though for the scope of this ticket, a separate test is a simpler approach as we won't have to adjust how they are called.

```py
    if os.getenv("TEST_CLIENT_TYPE") == "aio":
        list_resp =  await integration_client.sizes.list()
    else:
        list_resp =  integration_client.sizes.list()
```