### PR TITLE
Use deploy token instead of secrets.github_token

### DIFF
--- a/.github/workflows/python-client-gen.yml
+++ b/.github/workflows/python-client-gen.yml
@@ -25,7 +25,7 @@ jobs:
       id: cpr
       uses: peter-evans/create-pull-request@v4
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        ssh-key: "${{ secrets.COMMIT_KEY }}"
         commit-message: Re-generate Python Client
         committer: GitHub <noreply@github.com>
         author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>


### PR DESCRIPTION
An itch I want to scratch for debugging the "Expected — Waiting for status to be reported" issue which is blocking our tests to run in PRs. In researching the issue, I keep seeing suggested solutions around replacing the "secrets.github_token"- worth a shot 

https://luxiyalu.com/expected-waiting-for-status-to-be-reported/
https://medium.com/prompt/trigger-another-github-workflow-without-using-a-personal-access-token-f594c21373ef