### PR TITLE
revert Use deploy token instead of secrets.github_token #91

### DIFF
--- a/.github/workflows/python-client-gen.yml
+++ b/.github/workflows/python-client-gen.yml
@@ -21,12 +21,6 @@ jobs:
         path: ./DigitalOcean-public.v2.yaml
     - name: Generate Python client
       run: make generate
-    - name: grab ssh
-      uses: webfactory/ssh-agent@v0.2.0
-      with:
-        ssh-private-key: ${{ secrets.COMMIT_KEY }}
-    - name: Checkout via SSH
-      run: git clone git@github.com:peter-evans/create-pull-request.git .    
     - name: Create Pull Request
       id: cpr
       uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
revert Use deploy token instead of secrets.github_token #91 

Solution involved passing a ssh key to a third party plugin that is not worth doing right now
