### PR TITLE
tests: test_app_lifecycle: Add app alert and fix deploy

### DIFF
--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -58,7 +58,11 @@ def test_app_lifecycle(integration_client: Client):
         assert alerts_resp["alerts"][0]["spec"]["rule"] == "DEPLOYMENT_LIVE"
 
         alert_id = alerts_resp["alerts"][0]["id"]
-        alert_req = {"emails": ["api-engineering@digitalocean.com"]}
+
+        # assign_alert_destinations requires an email address that has access to the app
+        account_resp = integration_client.account.get()
+        assert account_resp is not None
+        alert_req = {"emails": [account_resp["account"]["email"]]}
 
         alert_resp = integration_client.apps.assign_alert_destinations(
             app_id, alert_id, alert_req


### PR DESCRIPTION
This PR addresses a TODO in the test to test app alerts.  There is no
need to trigger the alert to test it.  This patch adds a "DEPLOYMENT_LIVE" 
alert rule and checks the list of alerts to see that the rule exists.
There is no need to trigger the alert to be able to list the alert; we
are listing the alerts configured for the app.  If there are failures for
this test we may need to wait for the app to begin deployment so that the
spec is evaluated and alerts created; generally this happens very quickly.

Also, the app spec has an incorrect `run_command` which will result in the
deploy failing with a "bin/api not found" message.  The `run_command`
entry can be removed entirely as the sample will work with the defaults.