### PR TITLE
Add directive removing accept and content-type arguments from the apps.Create method.

### DIFF
--- a/client_gen_config.md
+++ b/client_gen_config.md
@@ -50,4 +50,10 @@ directive:
           }
         ]
       };
+
+  # Remove accept and content-type arguments from the app.Create method.
+  - from: openapi-document
+    where: '$.paths."/v2/apps".post'
+    transform: >
+      $["parameters"] = [];
 ```


### PR DESCRIPTION
The tests currently fail using the latest version of the OpenAPI spec. This is due to the `POST /v2/apps` method documenting `Accpet` and `Content-Type` paramaters. OpenAPI  has language that reads:
> If in is "header" and the name field is "Accept", "Content-Type" or "Authorization", the parameter definition SHALL be ignored.
https://swagger.io/specification/#parameter-object

This PR uses a directive to remove these for client generation. End users of this client are working with Python dicts, not JSON or YAML. So that should not cause any issue.

```
make download-spec
make clean
make generate
make test-mocked
```

Currently that fails with:

```
__________________________________________________ test_create __________________________________________________
tests/mocked/test_app.py:47: in test_create
    "routes": [],
../../../Library/Caches/pypoetry/virtualenvs/pydo-RO008Yys-py3.7/lib/python3.7/site-packages/azure/core/tracing/decorator.py:78: in wrapper_use_tracer
    return func(*args, **kwargs)
src/pydo/operations/_operations.py:23775: in create
    params=_params,
src/pydo/operations/_operations.py:259: in build_apps_create_request
    if accept is not None:
E   NameError: name 'accept' is not defined
```

After this change, it should now pass. The diff from a client generated with the newest OpenAPI spec without this change to one generated with this change includes:

```
--- a/src/pydo/operations/_operations.py
+++ b/src/pydo/operations/_operations.py
@@ -252,14 +252,15 @@ def build_apps_create_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     content_type = kwargs.pop("content_type", _headers.pop("Content-Type", None))  # type: Optional[str]
+    accept = _headers.pop("Accept", "application/json")
+
     # Construct URL
     _url = "/v2/apps"
 
     # Construct headers
-    if accept is not None:
-        _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
     if content_type is not None:
         _headers["Content-Type"] = _SERIALIZER.header("content_type", content_type, "str")
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
```