### PR TITLE
Fix 'Update DO_OPENAPI_COMMIT_SHA.txt step'

### DIFF
--- a/.github/workflows/python-client-gen.yml
+++ b/.github/workflows/python-client-gen.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Download spec file and Update DO_OPENAPI_COMMIT_SHA.txt
       run: |
         curl --fail https://api-engineering.nyc3.digitaloceanspaces.com/spec-ci/DigitalOcean-public-${{ github.event.inputs.openapi_short_sha }}.v2.yaml -o DigitalOcean-public.v2.yaml
-        ${{ github.event.inputs.openapi_short_sha }} > DO_OPENAPI_COMMIT_SHA.txt
+        echo ${{ github.event.inputs.openapi_short_sha }} > DO_OPENAPI_COMMIT_SHA.txt
       env:
         GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
     - uses: actions/upload-artifact@v2
@@ -26,7 +26,7 @@ jobs:
     - name: Checkout new Branch
       run: git checkout -b openapi-${{ github.event.inputs.openapi_short_sha }}/clientgen
       env:
-        GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}   
+        GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
     - name: Generate Python client
       run: make generate
     - name: Add and commit changes
@@ -37,8 +37,8 @@ jobs:
         git commit -m "[bot] Updated client based on openapi/${{ github.event.inputs.openapi_short_sha }}"
         git push --set-upstream origin ${{ github.event.inputs.openapi_short_sha }}
       env:
-        GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}  
+        GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
     - name: Create Pull Request
       run: gh pr create --title "[bot] Re-Generate w/ digitalocean/openapi ${{ github.event.inputs.openapi_short_sha }}" --body "Regenerate python client with the commit,${{ github.event.inputs.openapi_short_sha }}, pushed to digitalocean/openapi. Owners must review to confirm if integration/mocked tests need to be added to the client to reflect the changes." --head "openapi_trigger_${{ github.event.inputs.openapi_short_sha }}" -r owners
       env:
-        GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}    
+        GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
The client generation workflow is currently failing on the step where it writes the `openapi_short_sha` to file. 

```
  curl --fail https://api-engineering.nyc3.digitaloceanspaces.com/spec-ci/DigitalOcean-public-59be3f3.v2.yaml -o DigitalOcean-public.v2.yaml
  59be3f3 > DO_OPENAPI_COMMIT_SHA.txt
  shell: /usr/bin/bash -e {0}
  env:
    GH_TOKEN: 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 1280k  100 1280k    0     0  1479k      0 --:--:-- --:--:-- --:--:-- 1477k
/home/runner/work/_temp/2d0868b1-9121-4269-927d-3272fccdf644.sh: line 2: 59be3f3: command not found
Error: Process completed with exit code 127.
```

https://github.com/digitalocean/pydo/actions/runs/3397202176/jobs/5649113148#step:4:3