### PR TITLE
bump package version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydo"
-version = "0.1.0"
+version = "0.1.2"
 description = "The official client for interacting with the DigitalOcean API"
 authors = ["API Engineering <api-engineering@digitalocean.com>"]
 license = "Apache"


### PR DESCRIPTION
We need to create an initial release for the [tagging/releasing] dependencies (e.g. [github-changelog-generator](https://github.com/digitalocean/github-changelog-generator)) to work properly. 

We've merged updates to the generated client since manually publishing `0.1.1` to pypi, so this will serve as the commit we can tag for the initial github release. 