### PR TITLE
Format generated code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ generate: clean dev-dependencies
 		--use:@autorest/python@$(AUTOREST_PYTHON_VERSION) \
 		--package-version=$(PACKAGE_VERSION) \
 		--input-file=$(SPEC_FILE)
+	@poetry run black src
 
 .PHONY: install
 install: ## Install test dependencies


### PR DESCRIPTION
Adds a format command after code generation in the make target so the behavior is the same locally and in the workflow.