### PR TITLE
Add dependency on install target to generate.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ifndef SPEC_FILE
 generate: SPEC_FILE = $(LOCAL_SPEC_FILE)
 generate: dev-dependencies download-spec ## Generates the python client using the latest published spec first.
 endif
-generate: clean dev-dependencies
+generate: install clean dev-dependencies
 	@printf "=== Generating client with spec: $(SPEC_FILE)\n\n"; \
 	npm run autorest -- client_gen_config.md \
 		--use:@autorest/modelerfour@$(MODELERFOUR_VERSION) \


### PR DESCRIPTION
Looks like we need a  dependency on the `install` target in addition to installing poetry.

```
  FileNotFoundError

  [Errno 2] No such file or directory: b'/snap/bin/black'

  at /usr/lib/python3.8/os.py:601 in _execvpe
       597│         path_list = map(fsencode, path_list)
       598│     for dir in path_list:
       599│         fullname = path.join(dir, file)
       600│         try:
    →  601│             exec_func(fullname, *argrest)
       602│         except (FileNotFoundError, NotADirectoryError) as e:
       603│             last_exc = e
       604│         except OSError as e:
       605│             last_exc = e
make: *** [Makefile:38: generate] Error 1
```

https://github.com/digitalocean/openapi/actions/runs/3413887146/jobs/5681158401
