### PR TITLE
Add release workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+# Automatic release notes configuration
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-changelog
+  categories:
+    - title: "Breaking Changes :warning:"
+      labels:
+        - semver-major
+        - breaking-change
+    - title: "Features :tada:"
+      labels:
+        - semver-minor
+        - enhancement
+    - title: "Other Changes :hammer_and_pick: (Bug fixes, documenation, etc)"
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -14,6 +14,9 @@ changelog:
       labels:
         - semver-minor
         - enhancement
-    - title: "Other Changes :hammer_and_pick: (Bug fixes, documenation, etc)"
+    - title: Bug fixes 🐞
+      labels:
+        - bug
+    - title: "Other Changes :hammer_and_pick: (documentation, testing, etc)"
       labels:
         - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: tagged-release
+
+on:
+  push:
+    tags:
+      - "v[0-9].[0-9]+.[0-9]+"
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.5.0
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.3.1
+        with:
+          version: 1.1.13
+          virtualenvs-path: .venv
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: false
+
+      - name: Restore poetry cache
+        if: success() && !env.ACT
+        uses: actions/cache@v3
+        with:
+          path: $(poetry config cache-dir)
+          key: ubuntu-latest-poetry-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+
+      - name: Build
+        run: poetry build
+
+      - name: Upload a Build Artifacts
+        uses: actions/upload-artifact@v3.1.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish
+        run: poetry publish
+
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.5.0
+
+      - name: Download the Build Artifacts
+        uses: actions/download-artifact@v3.1.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create release
+        run: |
+          gh release create ${{ env.TAG }} /
+            dist/*
+            --title "${{ env.TAG }}" /
+            --generate-notes /
+            --draft
+        env:
+          TAG: ${GITHUB_REF#refs/*/}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,3 +61,4 @@ jobs:
             --draft
         env:
           TAG: ${GITHUB_REF#refs/*/}
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.5.0
 
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3.1
+        uses: snok/install-poetry@v1.3.3
         with:
           version: 1.1.13
           virtualenvs-path: .venv
@@ -42,6 +47,9 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+
+    needs: build-and-publish
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2.5.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Create release
         run: |
           gh release create ${{ env.TAG }} \
-           dist/*
+           dist/* \
            --title "${{ env.TAG }}" \
            --generate-notes \
            --draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Publish
         run: poetry publish
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
 
   release:
     runs-on: ubuntu-latest
@@ -55,18 +57,20 @@ jobs:
         uses: actions/checkout@v2.5.0
 
       - name: Download the Build Artifacts
-        uses: actions/download-artifact@v3.1.1
+        uses: actions/download-artifact@v3.0.1
         with:
           name: dist
           path: dist/
 
+      - name: Set TAG
+        run: echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
       - name: Create release
         run: |
-          gh release create ${{ env.TAG }} /
-            dist/*
-            --title "${{ env.TAG }}" /
-            --generate-notes /
-            --draft
+          gh release create ${{ env.TAG }} \
+           dist/*
+           --title "${{ env.TAG }}" \
+           --generate-notes \
+           --draft
         env:
-          TAG: ${GITHUB_REF#refs/*/}
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,8 +95,11 @@ number vor the tag.
 *Before pushing a tag*, the pyproject version needs to be bumped.
 
 1. Run `make changes` to review the merged PRs since last release.
+    * Review the tags on each PR and make sure they are categorized
+      appropriately.
 2. Determine the bump type (major, minor, patch).
-3. Run `BUMP=(bugfix|feature|breaking) make bump_version` to update the `pydo` version.
+3. Run `BUMP=(bugfix|feature|breaking) make bump_version` to update the `pydo`
+   version.
     * `BUMP` also accepts `(patch|minor|major)`
 4. Make a pull request with this change. It should be separate from PRs
    containing chagnes to the library (including regenerated code).
@@ -105,3 +108,5 @@ number vor the tag.
    Run `make tag` to tag the latest commit and push the tag to ORIGIN.
     * To tag an earlier commit, run `COMMIT=${commit} make tag`.
     * To push the tag to a different remote, run `ORIGIN=${REMOTE} make tag`.
+6. Once the release process completes, review the draft release for correctness
+   and publish the release. Also, ensure the release has been marked `Latest`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,3 +85,23 @@ We like these:
 ## Customizing the Client Using Patch Files
 
 On top of generating our client, we've added a few customizations to create an optimal user experience. These customizations can by making changes to the `_patch.py` file. To learn more about adding customizations, please follow Autorest's documentation for it [here](https://github.com/Azure/autorest.python/blob/autorestv3/docs/customizations.md)
+
+## Releasing `pydo`
+
+The repo uses GitHub workflows to publish a draft release when a new tag is
+pushed. We use [semver](https://semver.org/#summary) to determine the version
+number vor the tag.
+
+*Before pushing a tag*, the pyproject version needs to be bumped.
+
+1. Run `make changes` to review the merged PRs since last release.
+2. Determine the bump type (major, minor, patch).
+3. Run `BUMP=(bugfix|feature|breaking) make bump_version` to update the `pydo` version.
+    * `BUMP` also accepts `(patch|minor|major)`
+4. Make a pull request with this change. It should be separate from PRs
+   containing chagnes to the library (including regenerated code).
+5. *Once the version bump PR has been pushed*, tag the commit to trigger the
+   release workflow.
+   Run `make tag` to tag the latest commit and push the tag to ORIGIN.
+    * To tag an earlier commit, run `COMMIT=${commit} make tag`.
+    * To push the tag to a different remote, run `ORIGIN=${REMOTE} make tag`.

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ MODELERFOUR_VERSION="4.23.6"
 AUTOREST_PYTHON_VERSION="6.0.1"
 PACKAGE_VERSION?="dev"
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+ORIGIN ?= origin
+BUMP ?= patch
 
 ifeq (, $(findstring -m,$(PYTEST_ARGS)))
 	PYTEST_EXCLUDE_MARKS=-m "not real_billing"
@@ -98,3 +100,35 @@ generate-docs: ## Generate documentation for Client using Sphinx
 clean-docs: ## Delete everything in docs/build/html
 	cd docs && \
 	make clean
+
+.PHONY: _install_github_release_notes
+_install_github_release_notes:
+	@GO111MODULE=off go get -u github.com/digitalocean/github-changelog-generator
+
+.PHONY: changes
+changes: _install_github_release_notes
+	@echo "==> Merged PRs since last release"
+	@echo ""
+	@github-changelog-generator -org digitalocean -repo pydo
+
+.PHONY: version
+version:
+	@poetry version
+
+.PHONY: _install_sembump
+_install_sembump:
+	@echo "=> installing/updating sembump tool"
+	@echo ""
+	@GO111MODULE=off go get -u github.com/jessfraz/junk/sembump
+
+.PHONY: bump_version
+bump_version: _install_sembump
+	@echo "==> BUMP=${BUMP} bump_version"
+	@echo ""
+	@ORIGIN=${ORIGIN} scripts/bumpversion.sh
+
+.PHONY: tag
+tag:
+	@echo "==> ORIGIN=${ORIGIN} COMMIT=${COMMIT} tag"
+	@echo ""
+	@ORIGIN=${ORIGIN} scripts/tag.sh

--- a/scripts/bumpversion.sh
+++ b/scripts/bumpversion.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ORIGIN=${ORIGIN:-origin}
+
+# Bump defaults to patch. We provide friendly aliases
+# for patch, minor and major
+BUMP=${BUMP:-patch}
+case "$BUMP" in
+  feature | minor)
+    BUMP="minor"
+    ;;
+  breaking | major)
+    BUMP="major"
+    ;;
+  *)
+    BUMP="patch"
+    ;;
+esac
+
+# if [[ $(git status --porcelain) != "" ]]; then
+#   echo "Error: repo is dirty. Run git status, clean repo and try again."
+#   exit 1
+# elif [[ $(git status --porcelain -b | grep -e "ahead" -e "behind") != "" ]]; then
+#   echo "Error: repo has unpushed commits. Push commits to remote and try again."
+#   exit 1
+# fi  
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+poetry_version=$(poetry version)
+version="${poetry_version:5}"
+new_version="$(sembump --kind "$BUMP" "$version")"
+
+poetry version "${new_version#v}"
+
+echo ""

--- a/scripts/bumpversion.sh
+++ b/scripts/bumpversion.sh
@@ -19,15 +19,13 @@ case "$BUMP" in
     ;;
 esac
 
-# if [[ $(git status --porcelain) != "" ]]; then
-#   echo "Error: repo is dirty. Run git status, clean repo and try again."
-#   exit 1
-# elif [[ $(git status --porcelain -b | grep -e "ahead" -e "behind") != "" ]]; then
-#   echo "Error: repo has unpushed commits. Push commits to remote and try again."
-#   exit 1
-# fi  
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [[ $(git status --porcelain) != "" ]]; then
+  echo "Error: repo is dirty. Run git status, clean repo and try again."
+  exit 1
+elif [[ $(git status --porcelain -b | grep -e "ahead" -e "behind") != "" ]]; then
+  echo "Error: repo has unpushed commits. Bumping the version should not include other changes."
+  exit 1
+fi  
 
 poetry_version=$(poetry version)
 version="${poetry_version:5}"

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+ORIGIN=${ORIGIN:-origin}
+
+if [[ $(git status --porcelain) != "" ]]; then
+  echo "Error: repo is dirty. Run git status, clean repo and try again."
+  exit 1
+elif [[ $(git status --porcelain -b | grep -e "ahead" -e "behind") != "" ]]; then
+  echo "Error: repo has unpushed commits. Push commits to remote and try again."
+  exit 1
+fi  
+
+poetry_version=$(poetry version)
+tag="v${poetry_version:5}"
+
+git tag -m "release $tag" -a "$tag" $COMMIT && git push "$ORIGIN" tag "$tag"
+
+echo ""


### PR DESCRIPTION
This adds a release workflow (triggered by pushed tags) to the repo. 

The Makefile has been updated with the necessary make targets for users to run to bump the version of `pydo`. 
The CONTRIBUTING.md file to include information about how to release the project.

Lastly, a `release.yml` has been added to the root of `.github/` with the configuration for auto-generating release notes.