### PR TITLE
adding "install" to make generate-docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ lint-docs:
 	docker run -v $(ROOT_DIR):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "*.md"
 
 .PHONY: generate-docs
-generate-docs: ## Generate documentation for Client using Sphinx
+generate-docs: install ## Generate documentation for Client using Sphinx
 	@echo Generating documentation...;
 	@echo Converting poetry file to requirements.txt...; \
 	poetry export -f requirements.txt -o requirements.txt --without-hashes && \


### PR DESCRIPTION
pipeline is still failing because the make step "generate-docs" needs to do a poetry install