### PR TITLE
Add logic to handle if branch already exists

### DIFF
--- a/.github/workflows/python-client-gen.yml
+++ b/.github/workflows/python-client-gen.yml
@@ -1,4 +1,4 @@
-name: Python Client Generation something
+name: Python Client Generation
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/python-client-gen.yml
+++ b/.github/workflows/python-client-gen.yml
@@ -1,4 +1,4 @@
-name: Python Client Generation
+name: Python Client Generation something
 on:
   workflow_dispatch:
     inputs:
@@ -6,6 +6,10 @@ on:
         description: 'The short commit sha that triggered the workflow'
         required: true
         type: string
+
+env:
+  NEW_BRANCH: openapi-${{ github.event.inputs.openapi_short_sha }}/clientgen
+
 jobs:
   Generate-Python-Client:
     runs-on: ubuntu-latest
@@ -28,7 +32,7 @@ jobs:
         path: ./DigitalOcean-public.v2.yaml
 
     - name: Checkout new Branch
-      run: git checkout -b openapi-${{ github.event.inputs.openapi_short_sha }}/clientgen
+      run: git checkout -B ${{ env.NEW_BRANCH }} #If -B is given, <new-branch> is created if it doesn’t exist; otherwise, it is reset. 
       env:
         GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
 
@@ -46,16 +50,21 @@ jobs:
     - name: Generate Python client documentation
       run: make generate-docs
     - name: Add and commit changes
+      id: add-commit-changes
+      continue-on-error: true
       run: |
         git config --global user.email "api-engineering@digitalocean.com"
         git config --global user.name "API Engineering"
         git add .
-        git commit -m "[bot] Updated client based on openapi/${{ github.event.inputs.openapi_short_sha }}"
-        git push --set-upstream origin ${{ github.event.inputs.openapi_short_sha }}
+        git commit -m "[bot] Updated client based on ${{ env.NEW_BRANCH }}"
+        git push --set-upstream origin ${{ env.NEW_BRANCH }}
       env:
         GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
 
     - name: Create Pull Request
-      run: gh pr create --title "[bot] Re-Generate w/ digitalocean/openapi ${{ github.event.inputs.openapi_short_sha }}" --body "Regenerate python client with the commit,${{ github.event.inputs.openapi_short_sha }}, pushed to digitalocean/openapi. Owners must review to confirm if integration/mocked tests need to be added to the client to reflect the changes." --head "openapi_trigger_${{ github.event.inputs.openapi_short_sha }}" -r owners
+      id: create-pr
+      if: steps.add-commit-changes.outcome == 'success'
+      continue-on-error: true
+      run: gh pr create --title "[bot] Re-Generate w/ digitalocean/openapi ${{ github.event.inputs.openapi_short_sha }}" --body "Regenerate python client with the commit, [${{ github.event.inputs.openapi_short_sha }}](https://github.com/digitalocean/openapi/commit/${{ github.event.inputs.openapi_short_sha }}) , pushed to digitalocean/openapi. Owners must review to confirm if integration/mocked tests need to be added to the client to reflect the changes." --head "${{ env.NEW_BRANCH }}" -r digitalocean/api-cli
       env:
         GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/python-client-gen.yml
+++ b/.github/workflows/python-client-gen.yml
@@ -32,7 +32,7 @@ jobs:
         path: ./DigitalOcean-public.v2.yaml
 
     - name: Checkout new Branch
-      run: git checkout -B ${{ env.NEW_BRANCH }} #If -B is given, <new-branch> is created if it doesn’t exist; otherwise, it is reset. 
+      run:  git checkout -b ${{ env.NEW_BRANCH }} 
       env:
         GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
 
@@ -61,10 +61,18 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
 
+    - name: Check if branch existed
+      # If steps.create-pr was anything but successful, it's possible that
+      # the branch was created in previous pipeline runs so it should be manually deleted.
+      if: steps.add-commit-changes.outcome != 'success'
+      run: |
+        echo "Add and commit changes step failed. It's possible the branch ${{ env.NEW_BRANCH }} already existed. Please delete the branch and re-run the pipeline."
+        exit 1
+
     - name: Create Pull Request
       id: create-pr
       if: steps.add-commit-changes.outcome == 'success'
       continue-on-error: true
       run: gh pr create --title "[bot] Re-Generate w/ digitalocean/openapi ${{ github.event.inputs.openapi_short_sha }}" --body "Regenerate python client with the commit, [${{ github.event.inputs.openapi_short_sha }}](https://github.com/digitalocean/openapi/commit/${{ github.event.inputs.openapi_short_sha }}) , pushed to digitalocean/openapi. Owners must review to confirm if integration/mocked tests need to be added to the client to reflect the changes." --head "${{ env.NEW_BRANCH }}" -r digitalocean/api-cli
       env:
-        GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+        GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}  

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ lint-docs:
 	docker run -v $(ROOT_DIR):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "*.md"
 
 .PHONY: generate-docs
-generate-docs: install ## readthedocs requires a requirements.txt file, this step converts poetry file to requirements.txt file
+generate-docs: install ## readthedocs requires a requirements.txt file, this step converts poetry file to requirements.txt file before re-gen the docs
 	@echo Generating documentation...;
 	@echo Converting poetry file to requirements.txt...; \
 	poetry export -f requirements.txt -o requirements.txt --without-hashes && \ 

--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,10 @@ lint-docs:
 	docker run -v $(ROOT_DIR):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "*.md"
 
 .PHONY: generate-docs
-generate-docs: install
+generate-docs: install ## readthedocs requires a requirements.txt file, this step converts poetry file to requirements.txt file
 	@echo Generating documentation...;
 	@echo Converting poetry file to requirements.txt...; \
-	poetry export -f requirements.txt -o requirements.txt --without-hashes && \
+	poetry export -f requirements.txt -o requirements.txt --without-hashes && \ 
 	cd docs && \
 	poetry run sphinx-apidoc -o source/ ../src/pydo && \
 	poetry run make html

--- a/Makefile
+++ b/Makefile
@@ -88,13 +88,13 @@ lint-docs:
 	docker run -v $(ROOT_DIR):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "*.md"
 
 .PHONY: generate-docs
-generate-docs: install dev-dependencies
+generate-docs: install
 	@echo Generating documentation...;
 	@echo Converting poetry file to requirements.txt...; \
 	poetry export -f requirements.txt -o requirements.txt --without-hashes && \
 	cd docs && \
-	sphinx-apidoc -o source/ ../src/pydo && \
-	make html
+	poetry run sphinx-apidoc -o source/ ../src/pydo && \
+	poetry run make html
 
 .PHONY: clean-docs
 clean-docs: ## Delete everything in docs/build/html

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ docker-build:
 	docker build -t pydo:dev .
 
 .PHONY: docker-python
-docker-python: docker-build  ## Runs a python shel within a docker container
+docker-python: docker-build  ## Runs a python shell within a docker container
 	docker run -it --rm --name pydo pydo:dev python
 
 .PHONY: lint-docs
@@ -88,7 +88,7 @@ lint-docs:
 	docker run -v $(ROOT_DIR):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "*.md"
 
 .PHONY: generate-docs
-generate-docs: install ## Generate documentation for Client using Sphinx
+generate-docs: install dev-dependencies
 	@echo Generating documentation...;
 	@echo Converting poetry file to requirements.txt...; \
 	poetry export -f requirements.txt -o requirements.txt --without-hashes && \

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ lint-docs:
 generate-docs: install ## readthedocs requires a requirements.txt file, this step converts poetry file to requirements.txt file before re-gen the docs
 	@echo Generating documentation...;
 	@echo Converting poetry file to requirements.txt...; \
-	poetry export -f requirements.txt -o requirements.txt --without-hashes && \ 
+	poetry export -f requirements.txt -o requirements.txt --without-hashes && \
 	cd docs && \
 	poetry run sphinx-apidoc -o source/ ../src/pydo && \
 	poetry run make html

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ lint-docs:
 .PHONY: generate-docs
 generate-docs: install ## readthedocs requires a requirements.txt file, this step converts poetry file to requirements.txt file before re-gen the docs
 	@echo Generating documentation...;
-	@echo Converting poetry file to requirements.txt...; \
-	poetry export -f requirements.txt -o requirements.txt --without-hashes && \
+	@echo Converting poetry file to requirements.txt...; 
+	poetry export -f requirements.txt -o requirements.txt --without-hashes
 	cd docs && \
 	poetry run sphinx-apidoc -o source/ ../src/pydo && \
 	poetry run make html
@@ -99,7 +99,7 @@ generate-docs: install ## readthedocs requires a requirements.txt file, this ste
 .PHONY: clean-docs
 clean-docs: ## Delete everything in docs/build/html
 	cd docs && \
-	make clean
+	poetry run make clean
 
 .PHONY: _install_github_release_notes
 _install_github_release_notes:

--- a/poetry.lock
+++ b/poetry.lock
@@ -905,7 +905,7 @@ aio = ["aiohttp"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.2"
-content-hash = "66e3d8bd7fdec6ab309d3cff304b95bdf8a213f3182d1da9721bf2cf642c331d"
+content-hash = "512472fb520b3b7d1a98630bff6235d1617a8bf47c78ab9e99318b85dba3cdcb"
 
 [metadata.files]
 aiohttp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ responses = "^0.21.0"
 pytest-asyncio = "^0.19.0"
 aioresponses = "^0.7.3"
 Sphinx = "^5.3.0"
+sphinx-rtd-theme = "^1.1.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Add a check if the branch already exists. if `add and commit step fails`, the next step will fail and prompt user to delete branch and re-run. Hopefully we won't run into this situation often once the pipeline consistently works.

Also, resolves error in github actions "generate-docs" step: 

```
Run make generate-docs
poetry install --no-interaction -E aio
Installing dependencies from lock file

No dependencies to install or update

Installing the current project: pydo (0.1.2)
Generating documentation...
Converting poetry file to requirements.txt...
/bin/sh: 4: sphinx-apidoc: not found
make: *** [Makefile:93: generate-docs] Error 12[7](https://github.com/digitalocean/pydo/actions/runs/3431821144/jobs/5720400506#step:9:8)
```