### PR TITLE
Add changelist.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ pydo.egg-info
 DigitalOcean-public.v2.yaml
 node_modules/
 testscript.py
+changelist.md


### PR DESCRIPTION
The file is created as part of the workflow changes here: https://github.com/digitalocean/pydo/pull/134 It probably doesn't need to be checked in as it is only used for the PR template. 

It is causing PRs to fail as the linter doesn't like that it uses a level two header (`##`) at the top of the file, but it makes sense in the context of how it is used. https://github.com/digitalocean/pydo/pull/137