### PR TITLE
Switch completely to `$DIGITALOCEAN_TOKEN`

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ resources on the respective DigitalOcean account.
 To run integration tests, run:
 
 ```shell
-DO_TOKEN=$DIGITALOCEAN_TOKEN make test-integration
+DIGITALOCEAN_TOKEN=... make test-integration
 ```
 
 #### Test Customizations

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ next page.
 ```python
 resp = self.client.ssh_keys.list(per_page=50, page=page)
 pages = resp.links.pages
-    if 'next' in pages.keys():
-        parsed_url = urlparse(pages['next'])
-        page = parse_qs(parsed_url.query)['page'][0]
-    else:
-        paginated = False
+if 'next' in pages.keys():
+    parsed_url = urlparse(pages['next'])
+    page = parse_qs(parsed_url.query)['page'][0]
+else:
+    paginated = False
 ```
 
 # **Contributing**

--- a/examples/customize_client_settings/add_http_logger.py
+++ b/examples/customize_client_settings/add_http_logger.py
@@ -9,9 +9,9 @@ LOG_FILE = "simple_ssh_keys.log"
 logging.basicConfig(filename=LOG_FILE, level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
 
-token = os.environ.get("DO_TOKEN")
+token = os.environ.get("DIGITALOCEAN_TOKEN")
 if token == "":
-    raise Exception("No DigitalOcean API token in DO_TOKEN env var")
+    raise Exception("No DigitalOcean API token in DIGITALOCEAN_TOKEN env var")
 # Initialize the client with the `logger` kwarg set to the application's logger.
 client = Client(
     token,

--- a/examples/customize_client_settings/custom_endpoint.py
+++ b/examples/customize_client_settings/custom_endpoint.py
@@ -5,9 +5,9 @@ from pydo import Client
 # Set the DO_ENDPOINT environment variable to a valid endpoint
 ENDPOINT = environ.get("DO_ENDPOINT") or "https://my.proxy"
 
-token = environ.get("DO_TOKEN")
+token = environ.get("DIGITALOCEAN_TOKEN")
 if token == "":
-    raise Exception("No DigitalOcean API token in DO_TOKEN env var")
+    raise Exception("No DigitalOcean API token in DIGITALOCEAN_TOKEN env var")
 
 # Initialize the client with the `endpoint` kwarg set to the custom endpoint.
 client = Client(token, endpoint=ENDPOINT)

--- a/examples/customize_client_settings/custom_request_timeout.py
+++ b/examples/customize_client_settings/custom_request_timeout.py
@@ -9,9 +9,9 @@ REGION = "nyc3"
 TIMEOUT_APP = 120
 TIMEOUT_KUBERNETES_CREATE = 1200
 
-token = environ.get("DO_TOKEN")
+token = environ.get("DIGITALOCEAN_TOKEN")
 if token == "":
-    raise Exception("No DigitalOcean API token in DO_TOKEN env var")
+    raise Exception("No DigitalOcean API token in DIGITALOCEAN_TOKEN env var")
 
 # Overwrite the default timeout set by the client with your own
 client = Client(token, timeout=TIMEOUT_APP)
@@ -35,7 +35,9 @@ new_cluster_req = {
 
 # Setting the `timeout` kwarg value for a specific operation method call will overwrite
 # the timeout for that request.
-cluster_create_resp = client.kubernetes.create_cluster(new_cluster_req, timeout=TIMEOUT_KUBERNETES_CREATE)
+cluster_create_resp = client.kubernetes.create_cluster(
+    new_cluster_req, timeout=TIMEOUT_KUBERNETES_CREATE
+)
 # Note: This method was chosen for the sake of the example. The `create_cluster`
 # kubernetes operation isn't a log running process (unlike the background action that
 # tracks the clusters provisioning state).

--- a/examples/customize_client_settings/custom_user_agent.py
+++ b/examples/customize_client_settings/custom_user_agent.py
@@ -5,9 +5,9 @@ from pydo import Client
 # Define a custom value for your application's user-agent
 USER_AGENT = "droplets-example"
 
-token = environ.get("DO_TOKEN")
+token = environ.get("DIGITALOCEAN_TOKEN")
 if token == "":
-    raise Exception("No DigitalOcean API token in DO_TOKEN env var")
+    raise Exception("No DigitalOcean API token in DIGITALOCEAN_TOKEN env var")
 
 if environ.get("DO_OVERWRITE_AGENT"):
     # When the `user_agent_overwrite` client setting is True, the `user_agent` value

--- a/examples/poc_droplets_volumes_sshkeys.py
+++ b/examples/poc_droplets_volumes_sshkeys.py
@@ -17,10 +17,10 @@ class DigitalOceanError(Exception):
 
 class DropletCreator:
     def __init__(self, *args, **kwargs):
-        token = os.environ.get("DO_TOKEN")
+        token = os.environ.get("DIGITALOCEAN_TOKEN")
         if token == "":
-            raise Exception("No DigitalOcean API token in DO_TOKEN env var")
-        self.client = Client(token=os.environ.get("DO_TOKEN"))
+            raise Exception("No DigitalOcean API token in DIGITALOCEAN_TOKEN env var")
+        self.client = Client(token=os.environ.get("DIGITALOCEAN_TOKEN"))
 
     def throw(self, message):
         raise DigitalOceanError(message) from None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,17 +16,17 @@ from pydo.aio import Client as aioClient
 def integration_client() -> Client:
     """Instantiates a pydo Client for use with integration tests.
 
-    The client requires the environment variable DO_TOKEN with a valid API
+    The client requires the environment variable DIGITALOCEAN_TOKEN with a valid API
     token.
 
     *IMPORTANT*: Use of this client will create real resources on the
     account.
     """
 
-    token = environ.get("DO_TOKEN", None)
+    token = environ.get("DIGITALOCEAN_TOKEN", None)
 
     if token is None:
-        pytest.fail("Expected environment variable DO_TOKEN")
+        pytest.fail("Expected environment variable DIGITALOCEAN_TOKEN")
 
     client = Client(token)
     return client
@@ -36,17 +36,17 @@ def integration_client() -> Client:
 def async_integration_client() -> aioClient:
     """Instantiates a pydo Client for use with integration tests.
 
-    The client requires the environment variable DO_TOKEN with a valid API
+    The client requires the environment variable DIGITALOCEAN_TOKEN with a valid API
     token.
 
     *IMPORTANT*: Use of this client will create real resources on the
     account.
     """
 
-    token = environ.get("DO_TOKEN", None)
+    token = environ.get("DIGITALOCEAN_TOKEN", None)
 
     if token is None:
-        pytest.fail("Expected environment variable DO_TOKEN")
+        pytest.fail("Expected environment variable DIGITALOCEAN_TOKEN")
 
     client = aioClient(token)
     return client


### PR DESCRIPTION
Our [API documentation](https://docs.digitalocean.com/reference/api/api-reference/#section/Authentication) uses `$DIGITALOCEAN_TOKEN`, so let's do the same, consistently.

Doing `DO_TOKEN=$DIGITALOCEAN_TOKEN ...` doesn't look that nice.

There are a few formatting changes which come from [psf/black](https://github.com/psf/black) as well; I'll add workflow which tests this when I get a few.