### PR TITLE
Remove Sphinx as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ isodate = ">=0.6.1"
 msrest = ">=0.7.1"
 typing-extensions = ">=3.7.4"
 aiohttp = { version = ">=3.0", optional = true }
-sphinx-rtd-theme = "^1.1.1"
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"


### PR DESCRIPTION
Removing sphinx as dependency and keeping it as a dev-dependencies in an effort to shrink package size.