### PR TITLE
Update documentation link in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["API Engineering <api-engineering@digitalocean.com>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/digitalocean/pydo"
-documentation = "https://github.com/digitalocean/pydo"
+documentation = "https://pydo.readthedocs.io/"
 keywords = ["digitalocean", "api", "client"]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
This points the documentation link to https://pydo.readthedocs.io/