### PR TITLE
Makefile: include more targets in help output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,26 +54,24 @@ else
 endif
 
 .PHONY: dev
-dev: dev-dependencies # Turns the current terminal into a poetry env
+dev: dev-dependencies ## Turns the current terminal into a poetry env
 	poetry shell
 
 .PHONY: lint-tests
-lint-tests: install
+lint-tests: install ## Lints the code
 	poetry run black --check --diff tests/. && \
 	poetry run pylint $(PYLINT_ARGS) tests/.
 
 .PHONY: test-mocked
-test-mocked: install
+test-mocked: install ## Runs the mock test suite
 	poetry run pytest -rA --tb=short tests/mocked/. $(PYTEST_ARGS)
 
 .PHONY: test-mocked
-test-integration: install
+test-integration: install ## Runs the integration test suite
 	poetry run pytest -rA --tb=short tests/integration/. $(PYTEST_EXCLUDE_MARKS) $(PYTEST_ARGS)
 
-# This command runs a single integration test
-# > make test-integration-single test=test_actions
 .PHONY: test-mocked
-test-integration-single: install
+test-integration-single: install ## This command runs a single integration test, e.g. > make test-integration-single test=test_actions
 	poetry run pytest -rA --tb=short tests/integration/. -k $(test)
 
 .PHONY: docker-build
@@ -123,13 +121,13 @@ _install_sembump:
 	@GO111MODULE=off go get -u github.com/jessfraz/junk/sembump
 
 .PHONY: bump_version
-bump_version: _install_sembump
+bump_version: _install_sembump ## Bumps the version
 	@echo "==> BUMP=${BUMP} bump_version"
 	@echo ""
 	@ORIGIN=${ORIGIN} scripts/bumpversion.sh
 
 .PHONY: tag
-tag:
+tag: ## Tags a release
 	@echo "==> ORIGIN=${ORIGIN} COMMIT=${COMMIT} tag"
 	@echo ""
 	@ORIGIN=${ORIGIN} scripts/tag.sh


### PR DESCRIPTION
Changes this:

```
$ make help
clean-docs                     Delete everything in docs/build/html
clean                          Removes all generated code (except _patch.py files)
dev-dependencies               Install development tooling
docker-python                  Runs a python shell within a docker container
download-spec                  Download Latest DO Spec
generate                       Generates the python client using the latest published spec first.
generate-docs                  readthedocs requires a requirements.txt file, this step converts poetry file to requirements.txt file before re-gen the docs
install                        Install test dependencies

NOTE: Run 'SPEC_FILE=path/to/local/spec make generate' to skip the download and use a local spec file.
```

To this:

```
$ make help
bump_version                   Bumps the version
clean-docs                     Delete everything in docs/build/html
clean                          Removes all generated code (except _patch.py files)
dev-dependencies               Install development tooling
dev                            Turns the current terminal into a poetry env
docker-python                  Runs a python shell within a docker container
download-spec                  Download Latest DO Spec
generate                       Generates the python client using the latest published spec first.
generate-docs                  readthedocs requires a requirements.txt file, this step converts poetry file to requirements.txt file before re-gen the docs
install                        Install test dependencies
lint-tests                     Lints the code
tag                            Tags a release
test-integration               Runs the integration test suite
test-integration-single        This command runs a single integration test, e.g. > make test-integration-single test=test_actions
test-mocked                    Runs the mock test suite

NOTE: Run 'SPEC_FILE=path/to/local/spec make generate' to skip the download and use a local spec file.
```