### PR TITLE
Change title of generated PR to include Openapi PR name

### DIFF
--- a/.github/workflows/python-client-gen.yml
+++ b/.github/workflows/python-client-gen.yml
@@ -81,12 +81,21 @@ jobs:
           echo "Add and commit changes step failed. It's possible the branch ${{ env.NEW_BRANCH }} already existed. Please delete the branch and re-run the pipeline."
           exit 1
 
+      - name: Set pr_title outputs 
+        id: pr_title_var
+        run: echo "PR_TITLE=$(gh pr list --search "${{ github.event.inputs.openapi_short_sha }}" --json title --jq '.[0].title' --repo danaelhe/openapi --state merged)" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check pr_title outputs 
+        run: echo ${{ steps.pr_title_var.outputs.PR_TITLE }}
+
       - name: Create Pull Request
         id: create-pr
         if: steps.add-commit-changes.outcome == 'success'
         run: |
           export CURRENT=$(cat DO_OPENAPI_COMMIT_SHA.txt)
           export TARGET=${{ github.event.inputs.openapi_short_sha }}
+          export TITLE="${{ steps.pr_title_var.outputs.PR_TITLE }}"
           envsubst < scripts/pr_body.md_tmpl > pr_body.md
           cat changelist.md >> pr_body.md
 
@@ -94,7 +103,7 @@ jobs:
           cat pr_body.md
 
           gh pr create \
-            --title "[bot] Re-Generate w/ digitalocean/openapi@$TARGET" \
+            --title "[bot] $TITLE: Re-Generated From digitalocean/openapi@$TARGET" \
             --body-file pr_body.md \
             --head "${{ env.NEW_BRANCH }}" \
             -r digitalocean/api-cli

--- a/.github/workflows/python-client-gen.yml
+++ b/.github/workflows/python-client-gen.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Set pr_title outputs 
         id: pr_title_var
-        run: echo "PR_TITLE=$(gh pr list --search "${{ github.event.inputs.openapi_short_sha }}" --json title --jq '.[0].title' --repo danaelhe/openapi --state merged)" >> $GITHUB_OUTPUT
+        run: echo "PR_TITLE=$(gh pr list --search "${{ github.event.inputs.openapi_short_sha }}" --json title --jq '.[0].title' --repo digitalocean/openapi --state merged)" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check pr_title outputs 


### PR DESCRIPTION
Making the generated PR titles more descriptive will make the changes in release notes more clear.