### PR TITLE
Update poetry version used in CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,7 +55,6 @@ jobs:
       fail-fast: true
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1.3.1
         with:
-          version: 1.1.13
+          version: 1.6.1
           virtualenvs-path: .venv
           virtualenvs-create: true
           virtualenvs-in-project: true


### PR DESCRIPTION
We specify poetry version 1.6.1 in most places, e.g.: 

https://github.com/digitalocean/pydo/blob/e51dee5dbc8c2887b15b96a797a661fd5c7a86fb/.github/workflows/pr.yaml#L23

https://github.com/digitalocean/pydo/blob/e51dee5dbc8c2887b15b96a797a661fd5c7a86fb/.github/workflows/python-client-gen.yml#L52

But it looks like we missed updating it here. This is what is causing dependabot PRs to fail the test step.

```
  The lock file is not compatible with the current version of Poetry.
  Upgrade Poetry to be able to read the lock file or, alternatively, regenerate the lock file with the `poetry lock` command.
```
https://github.com/digitalocean/pydo/actions/runs/6500827562/job/17657028618?pr=195