### PR TITLE
Prep v0.2.0 release.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydo"
-version = "0.1.7"
+version = "0.2.0"
 description = "The official client for interacting with the DigitalOcean API"
 authors = ["API Engineering <api-engineering@digitalocean.com>"]
 license = "Apache-2.0"

--- a/src/pydo/_version.py
+++ b/src/pydo/_version.py
@@ -4,4 +4,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "0.1.7"
+VERSION = "0.2.0"


### PR DESCRIPTION
We've had a lot of changes since the last release. We're overdue for another one.

```
~/projects/pydo$ make changes
==> Merged PRs since last release

- #254 - @digitalocean-engineering - [bot] Removes outdated database slugs: Re-Generated From digitalocean/openapi@25b90cb
- #253 - @digitalocean-engineering - [bot] apps: Add documentation for registry_credentials and GHCR images: Re-Generated From digitalocean/openapi@f0e997b
- #251 - @digitalocean-engineering - [bot] Add Database Event logs details to DO openapi: Re-Generated From digitalocean/openapi@32be7e9
- #249 - @digitalocean-engineering - [bot] DBAAS-4506: update kafka topic config options: Re-Generated From digitalocean/openapi@13ed326
- #248 - @digitalocean-engineering - [bot] Add ignore_dbs to online migration docs: Re-Generated From digitalocean/openapi@423c2d3
- #252 - @dependabot[bot] - Bump cryptography from 41.0.4 to 41.0.6
- #247 - @digitalocean-engineering - [bot] DBAAS-4482: Add missing storage_size_mib in public api for creating read-replica: Re-Generated From digitalocean/openapi@7a717b3
- #246 - @digitalocean-engineering - [bot] Database User ACLS - make 'id' optional: Re-Generated From digitalocean/openapi@a4755ec
- #244 - @digitalocean-engineering - [bot] Add app platform metric endpoints: Re-Generated From digitalocean/openapi@352faf3
- #243 - @dependabot[bot] - Bump urllib3 from 1.26.17 to 1.26.18
- #241 - @digitalocean-engineering - [bot] Kafka topic management - fixes + examples: Re-Generated From digitalocean/openapi@b0a1e19
- #240 - @digitalocean-engineering - [bot] Add support for scalable storage: Re-Generated From digitalocean/openapi@604eca4
- #239 - @digitalocean-engineering - [bot] APPS-7325 - deprecate app component routing/cors config: Re-Generated From digitalocean/openapi@ff8c689
- #238 - @andrewsomething - Regenerate requirements.txt
- #221 - @dependabot[bot] - Bump urllib3 from 1.26.12 to 1.26.17
- #199 - @dependabot[bot] - Bump cryptography from 38.0.3 to 41.0.4
- #198 - @dependabot[bot] - Bump requests from 2.28.1 to 2.31.0
- #197 - @dependabot[bot] - Bump pygments from 2.13.0 to 2.15.0
- #196 - @dependabot[bot] - Bump certifi from 2022.9.24 to 2023.7.22
- #195 - @dependabot[bot] - Bump aiohttp from 3.8.3 to 3.8.5
- #237 - @andrewsomething - Update poetry version used in CI
- #236 - @digitalocean-engineering - [bot] apps: add deploy_on_push.enabled to image source spec.: Re-Generated From digitalocean/openapi@5296e9e
- #235 - @digitalocean-engineering - [bot] Update notification.yml: Re-Generated From digitalocean/openapi@9d239ea
- #233 - @digitalocean-engineering - [bot] APPS-7700 Add digest field to the image source spec: Re-Generated From digitalocean/openapi@bc1bc43
- #229 - @digitalocean-engineering - [bot] fix: make period a required field for uptime alert: Re-Generated From digitalocean/openapi@f4200bf
- #228 - @shivam-Purohit - feature: pre-commit
- #227 - @shivam-Purohit - .gitignore does not ignore venv files 
- #225 - @work-mohit - added test mocked tests for droplets - 1
- #224 - @digitalocean-engineering - [bot] Add documentation for DBaaS Kafka  support: Re-Generated From digitalocean/openapi@a5a2b6a
- #223 - @vishalrajofficial - added mocked tests for droplets - part 1
- #218 - @work-mohit - added mocked tests for databases - part 4
- #217 - @work-mohit - added mocked tests for databases - part 3
- #219 - @Sanket-0510 - Add Mock Test: Uptime 
- #216 - @work-mohit - added mocked tests for databases - part 2
- #215 - @work-mohit - added mocked tests for databases - part 1
- #214 - @shivam-Purohit - Add Mocked Tests: Volume Actions
- #202 - @digitalocean-engineering - [bot] kubernetes: fix /credentials endpoint URL: Re-Generated From digitalocean/openapi@6f7c147
- #200 - @danaelhe - Add retries documentation
- #192 - @digitalocean-engineering - [bot] Re-Generate w/ digitalocean/openapi@555f840
- #193 - @danaelhe - Change title of generated PR to include Openapi PR name
```