### PR TITLE
Prep v0.3.0 Release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydo"
-version = "0.2.0"
+version = "0.3.0"
 description = "The official client for interacting with the DigitalOcean API"
 authors = ["API Engineering <api-engineering@digitalocean.com>"]
 license = "Apache-2.0"

--- a/src/pydo/_version.py
+++ b/src/pydo/_version.py
@@ -4,4 +4,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "0.2.0"
+VERSION = "0.3.0"


### PR DESCRIPTION
A lot of changes since last release:

- #288 - @digitalocean-engineering - [bot] Add OpenAPI spec for dedicated egress IPs: Re-Generated From digitalocean/openapi@88ef8cf
- #286 - @digitalocean-engineering - [bot] : Re-Generated From digitalocean/openapi@f331844
- #285 - @digitalocean-engineering - [bot] APPS-8711: container termination controls: Re-Generated From digitalocean/openapi@d8d3901
- #284 - @dependabot[bot] - Bump jinja2 from 3.1.3 to 3.1.4
- #283 - @digitalocean-engineering - [bot] APPS-8386: Deprecate tier upgrade/downgrade fields from instance size: Re-Generated From digitalocean/openapi@20b5ea6
- #281 - @dependabot[bot] - Bump idna from 3.4 to 3.7
- #280 - @digitalocean-engineering - [bot] dbaas: metrics_endpoints is readOnly: Re-Generated From digitalocean/openapi@9d76deb
- #279 - @digitalocean-engineering - [bot] Add opensearch engine details: Re-Generated From digitalocean/openapi@0b09b67
- #278 - @KylePeterDavies - fix(docs): Changes $DIGITALOCEAN_TOKEN to DIGITALOCEAN_TOKEN and changes get to list
- #276 - @digitalocean-engineering - [bot] Updates Droplet name field with character limits: Re-Generated From digitalocean/openapi@d26bc4e
- #275 - @digitalocean-engineering - [bot] Managed DB: Add MongoDB and Kafka Configurations to docs: Re-Generated From digitalocean/openapi@9b9ccd0
- #274 - @digitalocean-engineering - [bot] monitoring: Mention units for bandwidth metric.: Re-Generated From digitalocean/openapi@96b11dc
- #273 - @digitalocean-engineering - [bot] Volumes snapshot corrections: Re-Generated From digitalocean/openapi@916ed7e
- #272 - @digitalocean-engineering - [bot] update error response for non-snapshots: Re-Generated From digitalocean/openapi@605e551
- #271 - @digitalocean-engineering - [bot] Include DBaaS metrics endpoint operations: Re-Generated From digitalocean/openapi@2c75905
- #270 - @digitalocean-engineering - [bot] APPS-7813 Add autoscaling section to apps: Re-Generated From digitalocean/openapi@479ee7b
- #269 - @digitalocean-engineering - [bot] [NETPROD-3582] Added name query param in list certificates: Re-Generated From digitalocean/openapi@211e816
- #268 - @digitalocean-engineering - [bot] BILL-9714: Update docs for added invoice_id field: Re-Generated From digitalocean/openapi@a7cf342
- #267 - @dependabot[bot] - Bump cryptography from 42.0.2 to 42.0.4
- #266 - @digitalocean-engineering - [bot] Include PG Replication User Option: Re-Generated From digitalocean/openapi@6748be6
- #265 - @dependabot[bot] - Bump cryptography from 42.0.0 to 42.0.2
- #263 - @digitalocean-engineering - [bot] droplet: Document that enabling IPv6 requires OS-level config changes.: Re-Generated From digitalocean/openapi@4087119
- #262 - @dependabot[bot] - Bump cryptography from 41.0.6 to 42.0.0
- #261 - @digitalocean-engineering - [bot] Include DBAAS standby Nodes: Re-Generated From digitalocean/openapi@6e029d2
- #260 - @dependabot[bot] - Bump jinja2 from 3.1.2 to 3.1.3
- #259 - @danaelhe - Update README.md with known projects delete issue
- #258 - @digitalocean-engineering - [bot] APPS-8033 Add the RUN_RESTARTED log type: Re-Generated From digitalocean/openapi@a0a7ddf
- #257 - @digitalocean-engineering - [bot] Add UpdateUser endpoint for Databases: Re-Generated From digitalocean/openapi@cbd1bc6
- #256 - @digitalocean-engineering - [bot] List of possible events type: Re-Generated From digitalocean/openapi@e3fe224

[NETPROD-3582]: https://do-internal.atlassian.net/browse/NETPROD-3582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ