### PR TITLE
[bot] apps: mark prefix matching for CORS allowed origins as deprecated: Re-Generated From digitalocean/openapi@d6bdeea

### DIFF
--- a/DO_OPENAPI_COMMIT_SHA.txt
+++ b/DO_OPENAPI_COMMIT_SHA.txt
@@ -1,1 +1,1 @@
-56fb9c0
+d6bdeea


### PR DESCRIPTION

## Python client generation

The change to regenerate the python client was triggered by
digitalocean/openapi@d6bdeea.

Note: Owners must review to confirm if integration or mocked tests need to be
updated to the client to reflect the changes."

The following pull requests were merged to digitalocean/openapi@main since the
previous commit (digitalocean/openapi@d6bdeea):

> Note: each PR should include a list of labels to help categorize the level
(semver) of changes included.

## Changelist

Current commit: digitalocean/openapi@56fb9c0 (2024-07-24T16:26:59Z)
Target commit: digitalocean/openapi@d6bdeea (2024-07-24T16:41:50Z)

* digitalocean/openapi#897: apps: mark prefix matching for CORS allowed origins as deprecated - 2024-07-24T16:41:50Z []
