### PR TITLE
Update from deprecated upload-artifact@v2 action.

### DIFF
--- a/.github/workflows/python-client-gen.yml
+++ b/.github/workflows/python-client-gen.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: DigitalOcean-public.v2
           path: ./DigitalOcean-public.v2.yaml


### PR DESCRIPTION
The client generation workflow is failing due to usage of the deprecated `upload-artifact@v2` action.

```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

https://github.com/digitalocean/pydo/actions/runs/10905133185