### PR TITLE
readthedocs: Set python version to 3.8 in .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.7"
+    python: "3.8"
   jobs:
     # need to change references of GeneratedClient to Client to avoid confusion
     pre_build:


### PR DESCRIPTION
https://github.com/digitalocean/pydo/commit/579f57d38f132685e76a73ce7bfcd2bff958519c got us one step closer, but now I'm seeing additional errors. `requirements.txt` is using  `>= "3.8.0"`  and `< "4.0.0"'` as the Python version constraint, but `.readthedocs.yaml` is using 3.7 for the build environment.

```
Ignoring sphinx-rtd-theme: markers 'python_full_version >= "3.8.0" and python_full_version < "4.0.0"' don't match your environment
```

:crossed_fingers: 