### PR TITLE
Add Mocked Tests: Droplets 

### DIFF
--- a/tests/mocked/test_droplets.py
+++ b/tests/mocked/test_droplets.py
@@ -917,3 +917,138 @@ def test_list_associated_resources(mock_client: Client, mock_client_url):
     resp = mock_client.droplets.list_associated_resources(droplet_id)
 
     assert expected == resp
+
+@responses.activate
+def test_destroy_with_associated_resources_selective(mock_client: Client, mock_client_url):
+    """Mocks the droplets selectively destroy with associated resources operation."""
+
+    droplet_id = 3164444
+
+    responses.add(
+        responses.DELETE,
+        f"{mock_client_url}/v2/droplets/{droplet_id}/destroy_with_associated_resources/selective",
+        status=202,
+    )
+
+    resp = mock_client.droplets.destroy_with_associated_resources_selective(droplet_id)
+
+    assert resp is None
+
+@responses.activate
+def test_destroy_with_associated_resources_dangerous(mock_client: Client, mock_client_url):
+    """Mocks the droplets destroy with associated resources dangerous."""
+
+    droplet_id = 3164444
+
+    responses.add(
+        responses.DELETE,
+        f"{mock_client_url}/v2/droplets/{droplet_id}/destroy_with_associated_resources/dangerous",
+        status=202,
+    )
+
+    resp = mock_client.droplets.destroy_with_associated_resources_dangerous(droplet_id, x_dangerous=True)
+
+    assert resp is None
+
+@responses.activate
+def test_get_destroy_associated_resources_status(mock_client: Client, mock_client_url):
+    """Mocks the droplets check status of a droplet with associated resources operation"""
+    
+    expected = {
+        "droplet": {
+            "id": "187000742",
+            "name": "ubuntu-s-1vcpu-1gb-nyc1-01",
+            "destroyed_at": "2020-04-01T18:11:49Z"
+            },
+        "resources": {
+            "reserved_ips": [
+            {
+            "id": "6186916",
+            "name": "45.55.96.47",
+            "destroyed_at": "2020-04-01T18:11:44Z"
+            }
+            ],
+            "floating_ips": [
+            {
+            "id": "6186916",
+            "name": "45.55.96.47",
+            "destroyed_at": "2020-04-01T18:11:44Z"
+            }
+            ],
+            "snapshots": [
+            {
+            "id": "61486916",
+            "name": "ubuntu-s-1vcpu-1gb-nyc1-01-1585758823330",
+            "destroyed_at": "2020-04-01T18:11:44Z"
+            }
+            ],
+            "volumes": [ ],
+            "volume_snapshots": [
+            {
+            "id": "edb0478d-7436-11ea-86e6-0a58ac144b91",
+            "name": "volume-nyc1-01-1585758983629",
+            "destroyed_at": "2020-04-01T18:11:44Z"
+            }
+            ]
+        },
+        "completed_at": "2020-04-01T18:11:49Z",
+        "failures": 0
+    }
+    
+    droplet_id = 3164444
+
+    responses.add(
+        responses.GET,
+        f"{mock_client_url}/v2/droplets/{droplet_id}/destroy_with_associated_resources/status",
+        json=expected,
+        status=200,
+    )
+
+    resp = mock_client.droplets.get_destroy_associated_resources_status(droplet_id)
+
+    assert expected == resp
+
+@responses.activate
+def test_destroy_retry_with_associated_resources(mock_client: Client, mock_client_url):
+    """Mocks the droplets retry destroy with associated resources operation"""
+
+    droplet_id = 3164444
+
+    responses.add(
+        responses.POST,
+        f"{mock_client_url}/v2/droplets/{droplet_id}/destroy_with_associated_resources/retry",
+        status=202,
+    )
+
+    resp = mock_client.droplets.destroy_retry_with_associated_resources(droplet_id)
+
+    assert resp is None
+
+@responses.activate
+def test_list_neighbors_ids(mock_client: Client, mock_client_url):
+    """Mocks the droplets list all neighbors operation"""
+
+    expected = {
+        "neighbor_ids": [
+            [
+                168671828,
+                168663509,
+                168671815
+            ],
+            [
+                168671883,
+                168671750
+            ]
+        ]
+    }
+
+    responses.add(
+        responses.GET,
+        f"{mock_client_url}/v2/reports/droplet_neighbors_ids", 
+        json=expected,
+        status=200,
+    )
+
+    resp = mock_client.droplets.list_neighbors_ids()
+
+    assert expected == resp

--- a/tests/mocked/test_droplets.py
+++ b/tests/mocked/test_droplets.py
@@ -918,8 +918,11 @@ def test_list_associated_resources(mock_client: Client, mock_client_url):
 
     assert expected == resp
 
+
 @responses.activate
-def test_destroy_with_associated_resources_selective(mock_client: Client, mock_client_url):
+def test_destroy_with_associated_resources_selective(
+    mock_client: Client, mock_client_url
+):
     """Mocks the droplets selectively destroy with associated resources operation."""
 
     droplet_id = 3164444
@@ -934,8 +937,11 @@ def test_destroy_with_associated_resources_selective(mock_client: Client, mock_c
 
     assert resp is None
 
+
 @responses.activate
-def test_destroy_with_associated_resources_dangerous(mock_client: Client, mock_client_url):
+def test_destroy_with_associated_resources_dangerous(
+    mock_client: Client, mock_client_url
+):
     """Mocks the droplets destroy with associated resources dangerous."""
 
     droplet_id = 3164444
@@ -946,55 +952,58 @@ def test_destroy_with_associated_resources_dangerous(mock_client: Client, mock_c
         status=202,
     )
 
-    resp = mock_client.droplets.destroy_with_associated_resources_dangerous(droplet_id, x_dangerous=True)
+    resp = mock_client.droplets.destroy_with_associated_resources_dangerous(
+        droplet_id, x_dangerous=True
+    )
 
     assert resp is None
+
 
 @responses.activate
 def test_get_destroy_associated_resources_status(mock_client: Client, mock_client_url):
     """Mocks the droplets check status of a droplet with associated resources operation"""
-    
+
     expected = {
         "droplet": {
             "id": "187000742",
             "name": "ubuntu-s-1vcpu-1gb-nyc1-01",
-            "destroyed_at": "2020-04-01T18:11:49Z"
-            },
+            "destroyed_at": "2020-04-01T18:11:49Z",
+        },
         "resources": {
             "reserved_ips": [
-            {
-            "id": "6186916",
-            "name": "45.55.96.47",
-            "destroyed_at": "2020-04-01T18:11:44Z"
-            }
+                {
+                    "id": "6186916",
+                    "name": "45.55.96.47",
+                    "destroyed_at": "2020-04-01T18:11:44Z",
+                }
             ],
             "floating_ips": [
-            {
-            "id": "6186916",
-            "name": "45.55.96.47",
-            "destroyed_at": "2020-04-01T18:11:44Z"
-            }
+                {
+                    "id": "6186916",
+                    "name": "45.55.96.47",
+                    "destroyed_at": "2020-04-01T18:11:44Z",
+                }
             ],
             "snapshots": [
-            {
-            "id": "61486916",
-            "name": "ubuntu-s-1vcpu-1gb-nyc1-01-1585758823330",
-            "destroyed_at": "2020-04-01T18:11:44Z"
-            }
+                {
+                    "id": "61486916",
+                    "name": "ubuntu-s-1vcpu-1gb-nyc1-01-1585758823330",
+                    "destroyed_at": "2020-04-01T18:11:44Z",
+                }
             ],
-            "volumes": [ ],
+            "volumes": [],
             "volume_snapshots": [
-            {
-            "id": "edb0478d-7436-11ea-86e6-0a58ac144b91",
-            "name": "volume-nyc1-01-1585758983629",
-            "destroyed_at": "2020-04-01T18:11:44Z"
-            }
-            ]
+                {
+                    "id": "edb0478d-7436-11ea-86e6-0a58ac144b91",
+                    "name": "volume-nyc1-01-1585758983629",
+                    "destroyed_at": "2020-04-01T18:11:44Z",
+                }
+            ],
         },
         "completed_at": "2020-04-01T18:11:49Z",
-        "failures": 0
+        "failures": 0,
     }
-    
+
     droplet_id = 3164444
 
     responses.add(
@@ -1007,6 +1016,7 @@ def test_get_destroy_associated_resources_status(mock_client: Client, mock_clien
     resp = mock_client.droplets.get_destroy_associated_resources_status(droplet_id)
 
     assert expected == resp
+
 
 @responses.activate
 def test_destroy_retry_with_associated_resources(mock_client: Client, mock_client_url):
@@ -1024,27 +1034,18 @@ def test_destroy_retry_with_associated_resources(mock_client: Client, mock_clien
 
     assert resp is None
 
+
 @responses.activate
 def test_list_neighbors_ids(mock_client: Client, mock_client_url):
     """Mocks the droplets list all neighbors operation"""
 
     expected = {
-        "neighbor_ids": [
-            [
-                168671828,
-                168663509,
-                168671815
-            ],
-            [
-                168671883,
-                168671750
-            ]
-        ]
+        "neighbor_ids": [[168671828, 168663509, 168671815], [168671883, 168671750]]
     }
 
     responses.add(
         responses.GET,
-        f"{mock_client_url}/v2/reports/droplet_neighbors_ids", 
+        f"{mock_client_url}/v2/reports/droplet_neighbors_ids",
         json=expected,
         status=200,
     )


### PR DESCRIPTION
Refers to issue #209 

Added tests for `droplets.destroy_with_associated_resources_selective`, `droplets. destroy_with_associated_resources_dangerous`, `droplets. get_destroy_associated_resources_status`, `droplets. destroy_retry_with_associated_resources`, and `droplets.list_neighbors_ids`