### PR TITLE
Adjust a release process: remove additional sembump dependency; updat…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,20 +101,21 @@ number vor the tag.
 1. Run `BUMP=(bugfix|feature|breaking) make bump_version` to update the `pydo`
    version.
     * `BUMP` also accepts `(patch|minor|major)`
-    
-    Command example:
-    ```
-    make BUMP=minor bump_version
-    ```
-1. Run `make generate` to update the version in the codebase. Make a pull request with this change. It should be separate from PRs
-   containing changes to the library (including regenerated code).
+
+  Command example:
+
+  ```code
+  make BUMP=minor bump_version
+  ```
+
+1. Run `make generate` to update the version in the codebase. Make a pull request with this change.
+It should be separate from PRs containing changes to the library (including regenerated code).
 1. Once the version bump PR has been pushed and merged, tag the commit to trigger the
    release workflow: run `make tag` to tag the latest commit and push the tag to ORIGIN.
-   
+
    Notes:
     * To tag an earlier commit, run `COMMIT=${commit} make tag`.
     * To push the tag to a different remote, run `ORIGIN=${REMOTE} make tag`.
-1. Once the release process completes, review the draft release for correctness
-   and publish the release. 
-   
-   Ensure the release has been marked `Latest`.
+1. Once the release process completes, review the draft release for correctness and publish the release.
+
+  Ensure the release has been marked `Latest`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ number vor the tag.
     * `BUMP` also accepts `(patch|minor|major)`
     
     Command example:
-    ```code
+    ```
     make BUMP=minor bump_version
     ```
 1. Run `make generate` to update the version in the codebase. Make a pull request with this change. It should be separate from PRs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,20 +94,27 @@ number vor the tag.
 
 *Before pushing a tag*, the pyproject version needs to be bumped.
 
-1. Run `make changes` to review the merged PRs since last release.
+1. Run `make changes` to review the merged PRs since last release and decide what kind of release you are doing (bugfix, feature or breaking).
     * Review the tags on each PR and make sure they are categorized
       appropriately.
-2. Determine the bump type (major, minor, patch).
-3. Run `BUMP=(bugfix|feature|breaking) make bump_version` to update the `pydo`
+
+1. Run `BUMP=(bugfix|feature|breaking) make bump_version` to update the `pydo`
    version.
     * `BUMP` also accepts `(patch|minor|major)`
-4. Run `make generate` to update the version in the codebase.
-5. Make a pull request with this change. It should be separate from PRs
+    
+    Command example:
+    ```code
+    make BUMP=minor bump_version
+    ```
+1. Run `make generate` to update the version in the codebase. Make a pull request with this change. It should be separate from PRs
    containing changes to the library (including regenerated code).
-6. *Once the version bump PR has been pushed and merged*, tag the commit to trigger the
-   release workflow.
-   Run `make tag` to tag the latest commit and push the tag to ORIGIN.
+1. Once the version bump PR has been pushed and merged, tag the commit to trigger the
+   release workflow: run `make tag` to tag the latest commit and push the tag to ORIGIN.
+   
+   Notes:
     * To tag an earlier commit, run `COMMIT=${commit} make tag`.
     * To push the tag to a different remote, run `ORIGIN=${REMOTE} make tag`.
-7. Once the release process completes, review the draft release for correctness
-   and publish the release. Also, ensure the release has been marked `Latest`.
+1. Once the release process completes, review the draft release for correctness
+   and publish the release. 
+   
+   Ensure the release has been marked `Latest`.

--- a/Makefile
+++ b/Makefile
@@ -114,14 +114,8 @@ changes: _install_github_release_notes
 version:
 	@poetry version
 
-.PHONY: _install_sembump
-_install_sembump:
-	@echo "=> installing/updating sembump tool"
-	@echo ""
-	@GO111MODULE=off go get -u github.com/jessfraz/junk/sembump
-
 .PHONY: bump_version
-bump_version: _install_sembump ## Bumps the version
+bump_version: ## Bumps the version
 	@echo "==> BUMP=${BUMP} bump_version"
 	@echo ""
 	@ORIGIN=${ORIGIN} scripts/bumpversion.sh

--- a/scripts/bumpversion.sh
+++ b/scripts/bumpversion.sh
@@ -7,15 +7,23 @@ ORIGIN=${ORIGIN:-origin}
 # Bump defaults to patch. We provide friendly aliases
 # for patch, minor and major
 BUMP=${BUMP:-patch}
+
+poetry_version=$(poetry version)
+version="${poetry_version:5}"
+IFS='.' read -r major minor patch <<< "$version"
+
 case "$BUMP" in
   feature | minor)
-    BUMP="minor"
+    minor=$((minor + 1))
+    patch=0
     ;;
   breaking | major)
-    BUMP="major"
+    major=$((major + 1))
+    minor=0
+    patch=0
     ;;
   *)
-    BUMP="patch"
+    patch=$((patch + 1))
     ;;
 esac
 
@@ -27,10 +35,7 @@ elif [[ $(git status --porcelain -b | grep -e "ahead" -e "behind") != "" ]]; the
   exit 1
 fi  
 
-poetry_version=$(poetry version)
-version="${poetry_version:5}"
-new_version="$(sembump --kind "$BUMP" "$version")"
-
+new_version="$major.$minor.$patch"
 poetry version "${new_version#v}"
 
 echo ""


### PR DESCRIPTION
…e release documentation with example, make it a bit shorter

This PR:
* removes `sembump` dependency that can be replaced by adding 5 short additional lines of bash code.
* updates the release notes to be more clear, add an example for bumping the version as this differs from how we usually define a new version while releasing in other DO repos.

Overall, this should provide a clearer understanding of the Pydo release process.