### PR TITLE
Prep v0.9.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydo"
-version = "0.8.0"
+version = "0.9.0"
 description = "The official client for interacting with the DigitalOcean API"
 authors = ["API Engineering <api-engineering@digitalocean.com>"]
 license = "Apache-2.0"

--- a/src/pydo/_version.py
+++ b/src/pydo/_version.py
@@ -4,4 +4,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "0.8.0"
+VERSION = "0.9.0"


### PR DESCRIPTION
Changes:

- #417 - @digitalocean-engineering - [bot] Added reserved ipv6 API specs: Re-Generated From digitalocean/openapi@31fb5b2
- #416 - @digitalocean-engineering - [bot] getagent parity with internal api: Re-Generated From digitalocean/openapi@44575ea
- #415 - @digitalocean-engineering - [bot] extend kubernetes cluster model with routing_agent flag: Re-Generated From digitalocean/openapi@5285969
- #413 - @digitalocean-engineering - [bot] Update one click api permissions: Re-Generated From digitalocean/openapi@8495f9e
- #411 - @digitalocean-engineering - [bot] GenAI: Add Anthropic API Key Endpoints: Re-Generated From digitalocean/openapi@25f2388
