### PR TITLE
Update github upload-artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: poetry build
 
       - name: Upload a Build Artifacts
-        uses: actions/upload-artifact@v3.1.1
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
Fixing the release pipeline.

v3.1.1 was deprecated.

https://github.com/digitalocean/pydo/actions/runs/13551071021