### PR TITLE
Prep v0.9.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydo"
-version = "0.9.0"
+version = "0.9.1"
 description = "The official client for interacting with the DigitalOcean API"
 authors = ["API Engineering <api-engineering@digitalocean.com>"]
 license = "Apache-2.0"

--- a/src/pydo/_version.py
+++ b/src/pydo/_version.py
@@ -4,4 +4,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "0.9.0"
+VERSION = "0.9.1"


### PR DESCRIPTION
Sorry, it's just to much work to clean up all v0.9.0 artefacts to be able to release with the same tag.

https://github.com/digitalocean/pydo/actions/runs/13551640449/job/37876389228#step:8:23

