### PR TITLE
Setting DigitalOcean API Token for Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ on the [DigitalOcean OpenAPI Specification](https://github.com/digitalocean/open
 ## Prerequisites
 
 - Python version: >= 3.7.2
+- Configuring the `DIGITALOCEAN_TOKEN` environment variable to set the DigitalOcean API Token.
 
 ## Installation
 


### PR DESCRIPTION
As title, I think it will be great to add the  DigitalOcean API Token setting in `Prerequisites` section.

And it can be good to execute codes in the `Quickstart` section.