### PR TITLE
urllib3: 2.6.0 , python : 3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ sphinxcontrib-serializinghtml==1.1.5 ; python_full_version >= "3.8.0" and python
 tomli==2.0.1 ; python_version >= "3.8" and python_version < "3.11"
 tomlkit==0.12.5 ; python_full_version >= "3.8.0" and python_full_version < "4.0.0"
 typing-extensions==4.12.0 ; python_version >= "3.8" and python_full_version < "4.0.0"
-urllib3==2.6.0 ; python_version >= "3.8" and python_full_version < "4.0.0"
+urllib3==2.6.0 ; python_version >= "3.9" and python_full_version < "4.0.0"
 wrapt==1.16.0 ; python_full_version >= "3.8.0" and python_full_version < "4.0.0"
 yarl==1.9.4 ; python_version >= "3.8" and python_full_version < "4.0.0"
 zipp==3.19.1 ; python_version >= "3.8" and python_version < "3.10"


### PR DESCRIPTION
Urllib3 v2.6.0 requires python>=3.9 the dependabot PR didn't update the required python version which was causing the https://app.readthedocs.org/projects/pydo/builds/30608425/ to fail