### PR TITLE
pydo_release_0.22.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydo"
-version = "0.21.0"
+version = "0.22.0"
 description = "The official client for interacting with the DigitalOcean API"
 authors = ["API Engineering <api-engineering@digitalocean.com>"]
 license = "Apache-2.0"

--- a/src/pydo/_version.py
+++ b/src/pydo/_version.py
@@ -4,4 +4,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "0.21.0"
+VERSION = "0.22.0"


### PR DESCRIPTION
Merged PRs since last release

- #585 - @SSharma-10 - urllib3: 2.6.0 , python : 3.9
- #584 - @dependabot[bot] - Bump cryptography from 43.0.1 to 44.0.1
- #583 - @dependabot[bot] - Bump urllib3 from 2.2.2 to 2.6.0
- #517 - @dependabot[bot] - Bump jinja2 from 3.1.4 to 3.1.6
- #516 - @dependabot[bot] - Bump requests from 2.32.2 to 2.32.4
- #581 - @digitalocean-engineering - [bot] VPC NAT Gateway GA prep: Re-Generated From digitalocean/openapi@6f71ecc