### PR TITLE
Managed Agents: spec-based session creation + high-level AgentSession interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ clean: ## Removes all generated code (except _patch.py files)
 	@find src/pydo -type f \
 		! -name "_patch.py" ! -name "custom_*.py" ! -name "exceptions.py" \
 		! -path "*/agents/__init__.py" ! -path "*/aio/agents/__init__.py" \
+		! -path "*/agents/session.py" ! -path "*/aio/agents/session.py" \
 		-exec rm -rf {} +
 
 .PHONY: download-spec

--- a/examples/agents/attach.py
+++ b/examples/agents/attach.py
@@ -1,0 +1,53 @@
+"""Attach to an EXISTING agent session and stream one turn.
+
+Like ``doctl agents attach``: connect to a session that already exists, send a
+prompt, and consume the SSE event feed through the high-level API — no thread,
+no raw event-string matching. attach() never destroys the session, so it stays
+alive for further turns.
+
+Get a SESSION_ID first by creating one (the session stays up):
+    AGENT_SPEC=... python examples/agents/create_session.py
+then copy the "session_id" it prints.
+
+Required env:
+  DIGITALOCEAN_TOKEN
+  PYDO_AGENTS_ENDPOINT   stage2: https://api.s2r1.internal.digitalocean.com
+  SESSION_ID             the session to attach to
+
+Optional env:
+  PROMPT                 message to send (default below)
+"""
+
+import os
+import sys
+
+from pydo import Client
+from pydo.agents import AgentEventType
+
+client = Client(
+    token=os.environ["DIGITALOCEAN_TOKEN"],
+    agents_endpoint=os.environ.get("PYDO_AGENTS_ENDPOINT"),
+)
+
+agent = client.agents.attach(os.environ["SESSION_ID"])
+prompt = os.environ.get("PROMPT", "In one short sentence, what is DigitalOcean?")
+
+print(f"[attached {agent.session_id}]\n>>> {prompt}\n", file=sys.stderr)
+
+stream = agent.run_streamed(prompt)  # opens the stream, sends input, yields events
+for event in stream:
+    if event.type == AgentEventType.TOKEN:
+        print(event.text, end="", flush=True)  # live reply -> stdout
+    elif event.type == AgentEventType.TOOL_CALL:
+        print(f"\n[tool] {event.tool_name}", file=sys.stderr)
+    elif event.type == AgentEventType.HITL_REQUESTED:
+        print(f"\n[hitl auto-approved] {event.request_id}", file=sys.stderr)
+
+result = stream.result
+print(
+    f"\n\n[{result.status}] captured {len(result.final_output)} chars "
+    f"(tokens out={result.usage.get('tokens_out')})",
+    file=sys.stderr,
+)
+# attach() leaves the session running; destroy it when done:
+#   SESSION_ID=... python examples/agents/destroy_session.py

--- a/examples/agents/create_session.py
+++ b/examples/agents/create_session.py
@@ -1,41 +1,26 @@
-"""Create a session.
+"""Create a session from an agent manifest (``agents.yaml``).
 
-Set DIGITALOCEAN_TOKEN (and PYDO_AGENTS_ENDPOINT for stage2).
+A session is created entirely from the agent spec — the runtime adapter,
+sandbox template, env vars, etc. are all defined in the manifest. The client
+uploads it verbatim (``Content-Type: application/x-yaml``); the server parses
+and validates it.
 
-Optional PYDO_AGENT_KIND (Private Beta server support):
-  CLAUDE_CODE  → coding-claude-code  (default)
-  OPENCODE     → coding-opencode
-  CODEX_CLI    → coding-codex
-  NONE         → coding-base (requires ops to enable AGENT_KIND_NONE on the server)
+Required env:
+  DIGITALOCEAN_TOKEN
+  PYDO_AGENTS_ENDPOINT  (stage2: https://api.s2r1.internal.digitalocean.com)
+  AGENT_SPEC            path to the agent spec YAML (default: agent-spec.yaml)
 """
 
 import json
 import os
 
 from pydo import Client
-from pydo.agents import AgentKind
 
-_AGENT_KINDS = {
-    "CLAUDE_CODE": AgentKind.CLAUDE_CODE,
-    "OPENCODE": AgentKind.OPENCODE,
-    "CODEX_CLI": AgentKind.CODEX_CLI,
-    "NONE": AgentKind.NONE,
-}
+spec_path = os.environ.get("AGENT_SPEC", "agent-spec.yaml")
+with open(spec_path, "r", encoding="utf-8") as fh:
+    manifest = fh.read()
 
 client = Client(token=os.environ["DIGITALOCEAN_TOKEN"])
-
-kind_name = os.environ.get("PYDO_AGENT_KIND", "CLAUDE_CODE").upper()
-try:
-    agent_kind = _AGENT_KINDS[kind_name]
-except KeyError as exc:
-    raise SystemExit(
-        f"Unknown PYDO_AGENT_KIND={kind_name!r}; "
-        f"use one of: {', '.join(_AGENT_KINDS)}"
-    ) from exc
-
-resp = client.agents.sessions.create(
-    agent_kind=agent_kind,
-    repo_hint="digitalocean/pydo",
-)
+resp = client.agents.sessions.create_from_manifest(manifest)
 
 print(json.dumps(resp, indent=2, default=str))

--- a/examples/agents/run_blocking.py
+++ b/examples/agents/run_blocking.py
@@ -1,0 +1,31 @@
+"""One-liner blocking run: create from spec -> run -> print -> destroy.
+
+The high-level API collapses the whole flow into ``agent.run(prompt)``, which
+blocks until the run finishes and returns the assembled output. The ``with``
+block auto-destroys the session on exit.
+
+Required env:
+  DIGITALOCEAN_TOKEN
+  PYDO_AGENTS_ENDPOINT   stage2: https://api.s2r1.internal.digitalocean.com
+  AGENT_SPEC             path to the agent spec YAML
+
+Optional env:
+  PROMPT
+"""
+
+import os
+
+from pydo import Client
+
+client = Client(
+    token=os.environ["DIGITALOCEAN_TOKEN"],
+    agents_endpoint=os.environ.get("PYDO_AGENTS_ENDPOINT"),
+)
+
+with open(os.environ.get("AGENT_SPEC", "agent-spec.yaml"), encoding="utf-8") as fh:
+    manifest = fh.read()
+
+prompt = os.environ.get("PROMPT", "In one short sentence, what is DigitalOcean?")
+
+with client.agents.start(manifest) as agent:  # auto-destroys on exit
+    print(agent.run(prompt).final_output)

--- a/examples/agents/session_e2e.py
+++ b/examples/agents/session_e2e.py
@@ -1,0 +1,146 @@
+"""End-to-end hosted-agents demo: create -> attach -> destroy.
+
+This single script walks the whole lifecycle the way an end user would:
+
+  1. create   — provision a session from an agents.yaml manifest (the spec
+                defines the runtime adapter, sandbox, env, etc.)
+  2. attach   — open the SSE event stream, send a prompt, and consume the
+                events as they arrive: render the agent's reply token-by-token,
+                surface tool calls, auto-approve HITL prompts, and capture the
+                assembled answer for programmatic use.
+  3. destroy  — tear the session down.
+
+stdout = the agent's streamed reply.   stderr = the play-by-play / status.
+
+Required env:
+  DIGITALOCEAN_TOKEN
+  PYDO_AGENTS_ENDPOINT   stage2: https://api.s2r1.internal.digitalocean.com
+  AGENT_SPEC             path to the agent spec YAML (agents.yaml manifest)
+
+Optional env:
+  PROMPT                 message to send (default: a short demo prompt)
+  RUN_TIMEOUT_SECONDS    how long to wait for the run to finish (default: 120)
+
+Example:
+  export DIGITALOCEAN_TOKEN=dop_v1_...
+  export PYDO_AGENTS_ENDPOINT=https://api.s2r1.internal.digitalocean.com
+  export AGENT_SPEC=/path/to/codex-agent-spec.yaml
+  python examples/agents/session_e2e.py
+"""
+
+import os
+import sys
+import threading
+import time
+
+from pydo import Client
+from pydo.agents import HITLOutcome, ResolutionSource
+
+
+def log(msg=""):
+    """Status line -> stderr (keeps stdout clean for the agent's reply)."""
+    print(msg, file=sys.stderr, flush=True)
+
+
+def main():
+    token = os.environ["DIGITALOCEAN_TOKEN"]
+    endpoint = os.environ.get("PYDO_AGENTS_ENDPOINT")
+    spec_path = os.environ.get("AGENT_SPEC", "agent-spec.yaml")
+    prompt = os.environ.get("PROMPT", "In one short sentence, what is DigitalOcean?")
+    run_timeout = float(os.environ.get("RUN_TIMEOUT_SECONDS", "120"))
+
+    with open(spec_path, "r", encoding="utf-8") as fh:
+        manifest = fh.read()
+
+    client = Client(token=token, agents_endpoint=endpoint)
+    log("endpoint: " + client.agents.base_url)
+
+    # --- 1. create -------------------------------------------------------
+    session = client.agents.sessions.create_from_manifest(manifest)
+    session_id = session.session.session_id
+    log("[created] %s  (%s)" % (session_id, session.session.status))
+
+    finished = threading.Event()
+    reply_chunks = []
+
+    # --- 2a. attach: consume the SSE event feed in the background --------
+    def consume_events():
+        try:
+            with client.agents.sessions.stream(session_id) as events:
+                for ev in events:
+                    etype = getattr(ev, "type", None)
+                    data = ev.get("data") or {}
+
+                    if etype == "run.started":
+                        log("\n[run started]")
+                    elif etype == "run.token_delta":
+                        text = data.get("text", "")
+                        reply_chunks.append(text)
+                        print(text, end="", flush=True)  # live reply -> stdout
+                    elif etype == "run.tool_call_started":
+                        log("\n[tool] %s ..." % data.get("name", "?"))
+                    elif etype == "run.tool_call_completed":
+                        log("[tool done] %s" % data.get("summary", "ok"))
+                    elif etype == "run.human_input_requested":
+                        # A HITL approval gates the run; auto-approve for the demo.
+                        req_id = data.get("hitl_id") or data.get("request_id")
+                        log("\n[HITL] auto-approving %s" % req_id)
+                        client.agents.sessions.resolve_hitl(
+                            session_id,
+                            req_id,
+                            outcome=HITLOutcome.APPROVE,
+                            source=ResolutionSource.OUT_OF_BAND,
+                        )
+                    elif etype == "run.completed":
+                        log(
+                            "\n[run completed] tokens in=%s out=%s cost=$%.4f"
+                            % (
+                                data.get("total_tokens_in"),
+                                data.get("total_tokens_out"),
+                                (data.get("run_cost_micros") or 0) / 1_000_000,
+                            )
+                        )
+                        finished.set()
+                        return
+                    elif etype == "run.failed":
+                        log(
+                            "\n[run failed] %s (code %s)"
+                            % (data.get("message"), data.get("code"))
+                        )
+                        finished.set()
+                        return
+                    else:
+                        log("\n[event] %s" % etype)
+        except Exception as exc:  # noqa: BLE001 - surface any stream error and unblock
+            log("\n[stream error] %r" % exc)
+            finished.set()
+
+    streamer = threading.Thread(target=consume_events, daemon=True)
+    streamer.start()
+    time.sleep(1)  # let the stream attach before submitting input
+
+    # --- 2b. attach: send the prompt ------------------------------------
+    log("\n>>> " + prompt + "\n")
+    run = client.agents.sessions.send_input(session_id, text=prompt)
+    log("[queued run] %s" % run.get("run_id"))
+
+    # --- 2c. wait for the run to finish (driven by the SSE feed) --------
+    if not finished.wait(timeout=run_timeout):
+        log("\n[timeout] no completion within %ss" % run_timeout)
+
+    # --- use the streamed data ------------------------------------------
+    reply = "".join(reply_chunks).strip()
+    log("\n[captured reply: %d chars / %d words]" % (len(reply), len(reply.split())))
+
+    # --- 3. destroy ------------------------------------------------------
+    try:
+        client.agents.sessions.destroy(session_id)
+        log("[destroyed] %s" % session_id)
+    except Exception as exc:  # noqa: BLE001
+        log("[destroy failed] %r" % exc)
+
+    return 0 if reply else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agents/session_e2e.py
+++ b/examples/agents/session_e2e.py
@@ -1,16 +1,14 @@
 """End-to-end hosted-agents demo: create -> attach -> destroy.
 
-This single script walks the whole lifecycle the way an end user would:
+Uses pydo's high-level agent interface, so consuming the SSE feed needs no
+manual wiring — no background thread, no completion event, no dispatching on
+raw ``run.*`` event strings, and no explicit teardown:
 
-  1. create   — provision a session from an agents.yaml manifest (the spec
-                defines the runtime adapter, sandbox, env, etc.)
-  2. attach   — open the SSE event stream, send a prompt, and consume the
-                events as they arrive: render the agent's reply token-by-token,
-                surface tool calls, auto-approve HITL prompts, and capture the
-                assembled answer for programmatic use.
-  3. destroy  — tear the session down.
-
-stdout = the agent's streamed reply.   stderr = the play-by-play / status.
+  * ``client.agents.start(manifest)`` creates the session and returns a handle
+    that auto-destroys when the ``with`` block exits.
+  * ``agent.run_streamed(prompt)`` opens the stream, sends the prompt, and
+    yields normalized, typed events (auto-approving HITL prompts by default).
+  * ``agent.run(prompt)`` is the blocking one-liner equivalent.
 
 Required env:
   DIGITALOCEAN_TOKEN
@@ -19,127 +17,53 @@ Required env:
 
 Optional env:
   PROMPT                 message to send (default: a short demo prompt)
-  RUN_TIMEOUT_SECONDS    how long to wait for the run to finish (default: 120)
-
-Example:
-  export DIGITALOCEAN_TOKEN=dop_v1_...
-  export PYDO_AGENTS_ENDPOINT=https://api.s2r1.internal.digitalocean.com
-  export AGENT_SPEC=/path/to/codex-agent-spec.yaml
-  python examples/agents/session_e2e.py
 """
 
 import os
 import sys
-import threading
-import time
 
 from pydo import Client
-from pydo.agents import HITLOutcome, ResolutionSource
-
-
-def log(msg=""):
-    """Status line -> stderr (keeps stdout clean for the agent's reply)."""
-    print(msg, file=sys.stderr, flush=True)
+from pydo.agents import AgentEventType
 
 
 def main():
-    token = os.environ["DIGITALOCEAN_TOKEN"]
-    endpoint = os.environ.get("PYDO_AGENTS_ENDPOINT")
     spec_path = os.environ.get("AGENT_SPEC", "agent-spec.yaml")
-    prompt = os.environ.get("PROMPT", "In one short sentence, what is DigitalOcean?")
-    run_timeout = float(os.environ.get("RUN_TIMEOUT_SECONDS", "120"))
-
     with open(spec_path, "r", encoding="utf-8") as fh:
         manifest = fh.read()
 
-    client = Client(token=token, agents_endpoint=endpoint)
-    log("endpoint: " + client.agents.base_url)
+    prompt = os.environ.get("PROMPT", "In one short sentence, what is DigitalOcean?")
 
-    # --- 1. create -------------------------------------------------------
-    session = client.agents.sessions.create_from_manifest(manifest)
-    session_id = session.session.session_id
-    log("[created] %s  (%s)" % (session_id, session.session.status))
+    client = Client(
+        token=os.environ["DIGITALOCEAN_TOKEN"],
+        agents_endpoint=os.environ.get("PYDO_AGENTS_ENDPOINT"),
+    )
 
-    finished = threading.Event()
-    reply_chunks = []
+    # create + auto-destroy via the context manager.
+    with client.agents.start(manifest) as agent:
+        print(f"[session {agent.session_id} | {agent.status}]", file=sys.stderr)
+        print(f">>> {prompt}\n", file=sys.stderr)
 
-    # --- 2a. attach: consume the SSE event feed in the background --------
-    def consume_events():
-        try:
-            with client.agents.sessions.stream(session_id) as events:
-                for ev in events:
-                    etype = getattr(ev, "type", None)
-                    data = ev.get("data") or {}
+        # attach: send the prompt and consume typed events as they stream in.
+        stream = agent.run_streamed(prompt)
+        for event in stream:
+            if event.type == AgentEventType.TOKEN:
+                print(event.text, end="", flush=True)  # live reply -> stdout
+            elif event.type == AgentEventType.TOOL_CALL:
+                print(f"\n[tool] {event.tool_name}", file=sys.stderr)
+            elif event.type == AgentEventType.HITL_REQUESTED:
+                print(f"\n[hitl auto-approved] {event.request_id}", file=sys.stderr)
 
-                    if etype == "run.started":
-                        log("\n[run started]")
-                    elif etype == "run.token_delta":
-                        text = data.get("text", "")
-                        reply_chunks.append(text)
-                        print(text, end="", flush=True)  # live reply -> stdout
-                    elif etype == "run.tool_call_started":
-                        log("\n[tool] %s ..." % data.get("name", "?"))
-                    elif etype == "run.tool_call_completed":
-                        log("[tool done] %s" % data.get("summary", "ok"))
-                    elif etype == "run.human_input_requested":
-                        # A HITL approval gates the run; auto-approve for the demo.
-                        req_id = data.get("hitl_id") or data.get("request_id")
-                        log("\n[HITL] auto-approving %s" % req_id)
-                        client.agents.sessions.resolve_hitl(
-                            session_id,
-                            req_id,
-                            outcome=HITLOutcome.APPROVE,
-                            source=ResolutionSource.OUT_OF_BAND,
-                        )
-                    elif etype == "run.completed":
-                        log(
-                            "\n[run completed] tokens in=%s out=%s cost=$%.4f"
-                            % (
-                                data.get("total_tokens_in"),
-                                data.get("total_tokens_out"),
-                                (data.get("run_cost_micros") or 0) / 1_000_000,
-                            )
-                        )
-                        finished.set()
-                        return
-                    elif etype == "run.failed":
-                        log(
-                            "\n[run failed] %s (code %s)"
-                            % (data.get("message"), data.get("code"))
-                        )
-                        finished.set()
-                        return
-                    else:
-                        log("\n[event] %s" % etype)
-        except Exception as exc:  # noqa: BLE001 - surface any stream error and unblock
-            log("\n[stream error] %r" % exc)
-            finished.set()
+        result = stream.result
+        print(
+            f"\n\n[{result.status}] "
+            f"tokens in={result.usage.get('tokens_in')} "
+            f"out={result.usage.get('tokens_out')} "
+            f"| captured {len(result.final_output)} chars",
+            file=sys.stderr,
+        )
 
-    streamer = threading.Thread(target=consume_events, daemon=True)
-    streamer.start()
-    time.sleep(1)  # let the stream attach before submitting input
-
-    # --- 2b. attach: send the prompt ------------------------------------
-    log("\n>>> " + prompt + "\n")
-    run = client.agents.sessions.send_input(session_id, text=prompt)
-    log("[queued run] %s" % run.get("run_id"))
-
-    # --- 2c. wait for the run to finish (driven by the SSE feed) --------
-    if not finished.wait(timeout=run_timeout):
-        log("\n[timeout] no completion within %ss" % run_timeout)
-
-    # --- use the streamed data ------------------------------------------
-    reply = "".join(reply_chunks).strip()
-    log("\n[captured reply: %d chars / %d words]" % (len(reply), len(reply.split())))
-
-    # --- 3. destroy ------------------------------------------------------
-    try:
-        client.agents.sessions.destroy(session_id)
-        log("[destroyed] %s" % session_id)
-    except Exception as exc:  # noqa: BLE001
-        log("[destroy failed] %r" % exc)
-
-    return 0 if reply else 1
+    # session is destroyed here.
+    return 0 if stream.status == "completed" else 1
 
 
 if __name__ == "__main__":

--- a/src/pydo/agents/__init__.py
+++ b/src/pydo/agents/__init__.py
@@ -23,6 +23,14 @@ from .custom_models import (
     SessionStatus,
 )
 from .custom_sessions import HarnessEventStream, HarnessStreamError, SessionsOperations
+from .session import (
+    AgentEvent,
+    AgentEventType,
+    AgentSession,
+    HITLPolicy,
+    RunResult,
+    RunStream,
+)
 
 DEFAULT_AGENTS_BASE_URL = "https://api.digitalocean.com"
 _ENV_VAR = "PYDO_AGENTS_ENDPOINT"
@@ -48,9 +56,33 @@ class AgentsResources:
     def base_url(self) -> str:
         return self._proxy._base_url
 
+    def start(self, manifest: "str | bytes") -> AgentSession:
+        """Create a session from an ``agents.yaml`` manifest and return a handle.
+
+        Use as a context manager to auto-destroy on exit::
+
+            with client.agents.start(manifest) as agent:
+                print(agent.run("hello").final_output)
+        """
+        resp = self.sessions.create_from_manifest(manifest)
+        get = getattr(resp, "get", None)
+        info = get("session") if get else None
+        session_id = (getattr(info or resp, "get", lambda *_: None))("session_id")
+        return AgentSession(self.sessions, session_id, raw=resp)
+
+    def attach(self, session_id: str) -> AgentSession:
+        """Return an :class:`AgentSession` handle for an existing session."""
+        return AgentSession(self.sessions, session_id)
+
 
 __all__ = [
     "AgentsResources",
+    "AgentSession",
+    "AgentEvent",
+    "AgentEventType",
+    "RunResult",
+    "RunStream",
+    "HITLPolicy",
     "SessionsOperations",
     "HarnessEventStream",
     "HarnessStreamError",

--- a/src/pydo/agents/custom_sessions.py
+++ b/src/pydo/agents/custom_sessions.py
@@ -3,10 +3,11 @@
 # Licensed under the Apache-2.0 License.
 # ------------------------------------
 """Sync Hosted Agents session operations (``/v2/agents/sessions/...``)."""
+
 from __future__ import annotations
 
 import json as _json
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Union
 from urllib.parse import quote
 
 from azure.core.exceptions import (
@@ -29,6 +30,24 @@ _ERROR_MAP = {
 }
 
 _BASE_PATH = "/v2/agents/sessions"
+
+# Private Beta contract: a session is created from an ``agents.yaml`` manifest
+# uploaded verbatim. The server routes on this media type (handlers.go:
+# isYAMLContentType) and parses the body as the agent spec.
+_YAML_MEDIA_TYPE = "application/x-yaml"
+
+
+def _manifest_bytes(manifest: Union[str, bytes]) -> bytes:
+    """Normalize an agents.yaml manifest to non-empty UTF-8 bytes."""
+    if isinstance(manifest, str):
+        data = manifest.encode("utf-8")
+    elif isinstance(manifest, (bytes, bytearray)):
+        data = bytes(manifest)
+    else:
+        raise TypeError("manifest must be a str or bytes YAML document")
+    if not data.strip():
+        raise ValueError("manifest is empty")
+    return data
 
 
 def _unwrap_harness_sse_chunk(chunk: Dict[str, Any]) -> Optional[Any]:
@@ -139,6 +158,8 @@ class SessionsOperations:
         path: str,
         *,
         body: Optional[Dict[str, Any]] = None,
+        content: Optional[Union[str, bytes]] = None,
+        content_type: Optional[str] = None,
         params: Optional[Dict[str, Any]] = None,
         stream: bool = False,
     ):
@@ -151,6 +172,10 @@ class SessionsOperations:
         if body is not None:
             headers["Content-Type"] = "application/json"
             kwargs["json"] = body
+        elif content is not None:
+            if content_type:
+                headers["Content-Type"] = content_type
+            kwargs["content"] = content
 
         request = HttpRequest(method, path, **kwargs)
         request.url = self._client.format_url(request.url)
@@ -190,19 +215,25 @@ class SessionsOperations:
             ),
         )
 
-    def create(
-        self,
-        *,
-        agent_kind: str,
-        repo_hint: Optional[str] = None,
-        idle_timeout_seconds: Optional[int] = None,
-    ) -> Any:
-        body: Dict[str, Any] = {"agent_kind": agent_kind}
-        if repo_hint is not None:
-            body["repo_hint"] = repo_hint
-        if idle_timeout_seconds is not None:
-            body["idle_timeout_seconds"] = idle_timeout_seconds
-        return self._parse_json(self._send("POST", _BASE_PATH, body=body))
+    def create_from_manifest(self, manifest: Union[str, bytes]) -> Any:
+        """Create a session from an ``agents.yaml`` manifest.
+
+        This is the supported creation path: the manifest defines everything
+        about the session (runtime adapter, sandbox, env vars, egress). It is
+        uploaded verbatim as ``application/x-yaml`` and the server owns parsing
+        and validation. There are no ``agent_kind``/``repo_hint`` arguments.
+
+        :param manifest: The agent spec as a YAML ``str`` or ``bytes`` document.
+        """
+        data = _manifest_bytes(manifest)
+        return self._parse_json(
+            self._send(
+                "POST",
+                _BASE_PATH,
+                content=data,
+                content_type=_YAML_MEDIA_TYPE,
+            ),
+        )
 
     def get(self, session_id: str) -> Any:
         return self._parse_json(

--- a/src/pydo/agents/session.py
+++ b/src/pydo/agents/session.py
@@ -1,0 +1,414 @@
+# ------------------------------------
+# Copyright (c) DigitalOcean.
+# Licensed under the Apache-2.0 License.
+# ------------------------------------
+"""High-level, self-contained agent interface over the Hosted Agents session API.
+
+The low-level :class:`~pydo.agents.custom_sessions.SessionsOperations` mirrors the
+REST endpoints one-to-one, which means consuming a run requires hand-wiring the
+SSE feed: spawn a reader, dispatch on raw ``run.*`` event strings, accumulate
+token deltas, resolve HITL prompts, and coordinate completion.
+
+This module wraps that into an ergonomic surface inspired by
+``openai-agents-python``::
+
+    with client.agents.start(manifest) as agent:        # create + auto-destroy
+        result = agent.run("Summarize the repo")        # blocking
+        print(result.final_output)
+
+        for event in agent.run_streamed("Now add tests"):  # streamed, typed
+            if event.type == AgentEventType.TOKEN:
+                print(event.text, end="")
+
+No threads, no raw event-string matching, no manual teardown.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from .custom_models import HITLOutcome, ResolutionSource, SessionStatus
+
+# Normalized event type -> raw SPI ``type`` it maps from.
+_RAW_TO_TYPE = {
+    "run.started": "run_started",
+    "run.token_delta": "token",
+    "run.tool_call_started": "tool_call",
+    "run.tool_call_completed": "tool_result",
+    "run.human_input_requested": "hitl_requested",
+    "run.human_input_received": "hitl_resolved",
+    "run.completed": "completed",
+    "run.failed": "failed",
+}
+
+_HITL_OUTCOMES = {
+    "approve": HITLOutcome.APPROVE,
+    "reject": HITLOutcome.REJECT,
+    "defer": HITLOutcome.DEFER,
+}
+
+# A HITL policy is either a fixed decision ("approve"/"reject"/"defer"), an
+# explicit HITLOutcome constant, a callable mapping an event -> decision, or
+# None to leave prompts unresolved for the caller to handle.
+HITLPolicy = Union[str, Callable[["AgentEvent"], Optional[str]], None]
+
+
+class AgentEventType:
+    """Normalized, friendly event kinds yielded by a run stream."""
+
+    RUN_STARTED = "run_started"
+    TOKEN = "token"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    HITL_REQUESTED = "hitl_requested"
+    HITL_RESOLVED = "hitl_resolved"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    OTHER = "other"
+
+
+class AgentEvent:
+    """A normalized view over a raw harness SSE event.
+
+    Exposes a stable :attr:`type` (see :class:`AgentEventType`) plus typed
+    accessors, while keeping the underlying event available as :attr:`raw`.
+    """
+
+    def __init__(self, raw: Any):
+        self.raw = raw
+        get = getattr(raw, "get", None)
+        self.raw_type: Optional[str] = get("type") if get else None
+        self.type = _RAW_TO_TYPE.get(self.raw_type or "", AgentEventType.OTHER)
+        data = get("data") if get else None
+        self.data = data if data is not None else {}
+        self.run_id: str = (get("run_id") if get else None) or ""
+
+    def _d(self, key: str, default: Any = None) -> Any:
+        get = getattr(self.data, "get", None)
+        return get(key, default) if get else default
+
+    @property
+    def text(self) -> str:
+        """Token text for ``TOKEN`` events ("" otherwise)."""
+        return self._d("text", "") or ""
+
+    @property
+    def tool_name(self) -> Optional[str]:
+        """Tool name for ``TOOL_CALL`` events."""
+        return self._d("name")
+
+    @property
+    def request_id(self) -> Optional[str]:
+        """HITL request id for ``HITL_REQUESTED`` / ``HITL_RESOLVED`` events."""
+        return self._d("hitl_id") or self._d("request_id")
+
+    @property
+    def usage(self) -> Dict[str, Any]:
+        """Token/cost totals for ``COMPLETED`` events."""
+        return {
+            "tokens_in": self._d("total_tokens_in"),
+            "tokens_out": self._d("total_tokens_out"),
+            "cost_micros": self._d("run_cost_micros"),
+        }
+
+    @property
+    def error(self) -> Optional[Dict[str, Any]]:
+        """Failure ``{code, message}`` for ``FAILED`` events."""
+        if self.type != AgentEventType.FAILED:
+            return None
+        return {"code": self._d("code"), "message": self._d("message")}
+
+    def __repr__(self) -> str:
+        return f"AgentEvent(type={self.type!r}, run_id={self.run_id!r})"
+
+
+class RunResult:
+    """The outcome of a single run: assembled output, usage, and raw events."""
+
+    def __init__(
+        self,
+        *,
+        run_id: Optional[str],
+        final_output: str,
+        events: List[AgentEvent],
+        usage: Dict[str, Any],
+        status: str,
+        error: Optional[Dict[str, Any]] = None,
+    ):
+        self.run_id = run_id
+        self.final_output = final_output
+        self.events = events
+        self.usage = usage
+        self.status = status  # "completed" | "failed" | "timeout"
+        self.error = error
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "completed"
+
+    def __str__(self) -> str:
+        return self.final_output
+
+    def __repr__(self) -> str:
+        return (
+            f"RunResult(status={self.status!r}, run_id={self.run_id!r}, "
+            f"chars={len(self.final_output)})"
+        )
+
+
+def _decide_hitl(policy: HITLPolicy, event: AgentEvent) -> Optional[str]:
+    """Resolve a HITL policy to a concrete outcome constant (or None)."""
+    decision: Any = policy(event) if callable(policy) else policy
+    if not decision:
+        return None
+    if isinstance(decision, str):
+        return _HITL_OUTCOMES.get(decision.lower(), decision)
+    return decision
+
+
+class RunStream:
+    """Iterable of :class:`AgentEvent` for one run.
+
+    Iterating yields normalized events, auto-resolves HITL prompts per the
+    configured policy, and accumulates the assembled output. After iteration,
+    :attr:`final_output`, :attr:`usage`, :attr:`status`, and :attr:`result`
+    are populated.
+    """
+
+    def __init__(
+        self,
+        *,
+        raw_stream: Any,
+        run_id: Optional[str],
+        session: "AgentSession",
+        hitl: HITLPolicy = "approve",
+        timeout: Optional[float] = None,
+    ):
+        self._raw = raw_stream
+        self.run_id = run_id
+        self._session = session
+        self._hitl = hitl
+        self._timeout = timeout
+        self._chunks: List[str] = []
+        self.events: List[AgentEvent] = []
+        self.usage: Dict[str, Any] = {}
+        self.status = "running"
+        self.error: Optional[Dict[str, Any]] = None
+
+    def __iter__(self):
+        deadline = time.monotonic() + self._timeout if self._timeout else None
+        try:
+            for raw in self._raw:
+                event = AgentEvent(raw)
+                self.events.append(event)
+
+                if event.type == AgentEventType.TOKEN:
+                    self._chunks.append(event.text)
+                elif event.type == AgentEventType.HITL_REQUESTED:
+                    self._auto_resolve(event)
+
+                yield event
+
+                if self._is_terminal(event):
+                    break
+                if deadline and time.monotonic() > deadline:
+                    self.status = "timeout"
+                    break
+        finally:
+            self.close()
+
+    def _auto_resolve(self, event: AgentEvent) -> None:
+        outcome = _decide_hitl(self._hitl, event)
+        if not outcome or not event.request_id:
+            return
+        try:
+            self._session.resolve_hitl(
+                event.request_id,
+                outcome=outcome,
+                source=ResolutionSource.OUT_OF_BAND,
+            )
+        except Exception:  # noqa: BLE001 - best-effort; surfaced via the feed
+            pass
+
+    def _is_terminal(self, event: AgentEvent) -> bool:
+        if self.run_id and event.run_id and event.run_id != self.run_id:
+            return False
+        if event.type == AgentEventType.COMPLETED:
+            self.usage = event.usage
+            self.status = "completed"
+            return True
+        if event.type == AgentEventType.FAILED:
+            self.error = event.error
+            self.status = "failed"
+            return True
+        return False
+
+    @property
+    def final_output(self) -> str:
+        return "".join(self._chunks).strip()
+
+    @property
+    def result(self) -> RunResult:
+        return RunResult(
+            run_id=self.run_id,
+            final_output=self.final_output,
+            events=self.events,
+            usage=self.usage,
+            status=self.status,
+            error=self.error,
+        )
+
+    def close(self) -> None:
+        closer = getattr(self._raw, "close", None)
+        if closer:
+            try:
+                closer()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def __enter__(self) -> "RunStream":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+
+class AgentSession:
+    """A self-managing handle to one hosted-agent session.
+
+    Wraps :class:`~pydo.agents.custom_sessions.SessionsOperations`, binding the
+    ``session_id`` so callers never re-pass it, and adds :meth:`run` /
+    :meth:`run_streamed`. Use as a context manager to auto-destroy on exit.
+    """
+
+    def __init__(self, sessions: Any, session_id: str, *, raw: Any = None):
+        self._sessions = sessions
+        self.session_id = session_id
+        self._raw = raw
+
+    @property
+    def sessions(self) -> Any:
+        """The underlying low-level operations object."""
+        return self._sessions
+
+    @property
+    def info(self) -> Any:
+        """The most recent session object (``{...}``), if known."""
+        raw = self._raw
+        if raw is None:
+            return None
+        get = getattr(raw, "get", None)
+        inner = get("session") if get else None
+        return inner if inner is not None else raw
+
+    @property
+    def status(self) -> Optional[str]:
+        info = self.info
+        get = getattr(info, "get", None)
+        return get("status") if get else None
+
+    def refresh(self) -> Any:
+        """Fetch and cache the latest session state."""
+        self._raw = self._sessions.get(self.session_id)
+        return self.info
+
+    def wait_until_ready(
+        self, *, timeout: float = 120.0, poll_interval: float = 2.0
+    ) -> "AgentSession":
+        """Block until the session reports ``READY`` (or raise)."""
+        deadline = time.monotonic() + timeout
+        while True:
+            status = (getattr(self.refresh(), "get", lambda *_: None))("status")
+            if status == SessionStatus.READY:
+                return self
+            if status in (SessionStatus.FAILED, SessionStatus.DESTROYED):
+                raise RuntimeError(f"session {self.session_id} is {status}")
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    f"session {self.session_id} not ready after {timeout}s"
+                )
+            time.sleep(poll_interval)
+
+    def run_streamed(
+        self,
+        prompt: str,
+        *,
+        hitl: HITLPolicy = "approve",
+        timeout: Optional[float] = 300.0,
+    ) -> RunStream:
+        """Send ``prompt`` and return a :class:`RunStream` of typed events.
+
+        The SSE subscription is opened *before* the input is submitted, so no
+        early events are missed — no caller-managed thread required.
+        """
+        raw_stream = self._sessions.stream(self.session_id)
+        run = self._sessions.send_input(self.session_id, text=prompt)
+        run_id = (getattr(run, "get", lambda *_: None))("run_id")
+        return RunStream(
+            raw_stream=raw_stream,
+            run_id=run_id,
+            session=self,
+            hitl=hitl,
+            timeout=timeout,
+        )
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        hitl: HITLPolicy = "approve",
+        timeout: Optional[float] = 300.0,
+    ) -> RunResult:
+        """Send ``prompt`` and block until the run finishes, returning a result."""
+        stream = self.run_streamed(prompt, hitl=hitl, timeout=timeout)
+        for _ in stream:
+            pass
+        return stream.result
+
+    # --- thin passthroughs (session id bound) ---------------------------
+    def send_input(self, text: str) -> Any:
+        return self._sessions.send_input(self.session_id, text=text)
+
+    def stream(self, **kwargs: Any) -> Any:
+        return self._sessions.stream(self.session_id, **kwargs)
+
+    def resolve_hitl(
+        self,
+        request_id: str,
+        *,
+        outcome: str,
+        reason: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> None:
+        self._sessions.resolve_hitl(
+            self.session_id,
+            request_id,
+            outcome=outcome,
+            reason=reason,
+            source=source,
+        )
+
+    def destroy(self) -> None:
+        self._sessions.destroy(self.session_id)
+
+    def __enter__(self) -> "AgentSession":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        try:
+            self.destroy()
+        except Exception:  # noqa: BLE001 - teardown best-effort
+            pass
+
+    def __repr__(self) -> str:
+        return f"AgentSession(session_id={self.session_id!r})"
+
+
+__all__ = [
+    "AgentEvent",
+    "AgentEventType",
+    "AgentSession",
+    "RunResult",
+    "RunStream",
+    "HITLPolicy",
+]

--- a/src/pydo/aio/agents/__init__.py
+++ b/src/pydo/aio/agents/__init__.py
@@ -11,6 +11,7 @@ from pydo.agents import resolve_agents_base_url
 from pydo.custom_extensions import _BaseURLProxy
 
 from .custom_sessions import AsyncHarnessEventStream, AsyncSessionsOperations
+from .session import AsyncAgentSession, AsyncRunStream
 
 
 class AsyncAgentsResources:
@@ -25,5 +26,27 @@ class AsyncAgentsResources:
     def base_url(self) -> str:
         return self._proxy._base_url
 
+    async def start(self, manifest: "str | bytes") -> AsyncAgentSession:
+        """Create a session from an ``agents.yaml`` manifest and return a handle.
 
-__all__ = ["AsyncAgentsResources", "AsyncSessionsOperations", "AsyncHarnessEventStream"]
+        Use as ``async with await client.agents.start(manifest) as agent:`` to
+        auto-destroy on exit.
+        """
+        resp = await self.sessions.create_from_manifest(manifest)
+        get = getattr(resp, "get", None)
+        info = get("session") if get else None
+        session_id = (getattr(info or resp, "get", lambda *_: None))("session_id")
+        return AsyncAgentSession(self.sessions, session_id, raw=resp)
+
+    def attach(self, session_id: str) -> AsyncAgentSession:
+        """Return an :class:`AsyncAgentSession` handle for an existing session."""
+        return AsyncAgentSession(self.sessions, session_id)
+
+
+__all__ = [
+    "AsyncAgentsResources",
+    "AsyncAgentSession",
+    "AsyncRunStream",
+    "AsyncSessionsOperations",
+    "AsyncHarnessEventStream",
+]

--- a/src/pydo/aio/agents/custom_sessions.py
+++ b/src/pydo/aio/agents/custom_sessions.py
@@ -3,10 +3,11 @@
 # Licensed under the Apache-2.0 License.
 # ------------------------------------
 """Async Hosted Agents session operations."""
+
 from __future__ import annotations
 
 import json as _json
-from typing import Any, AsyncIterator, Dict, List, Optional
+from typing import Any, AsyncIterator, Dict, List, Optional, Union
 from urllib.parse import quote
 
 from azure.core.exceptions import (
@@ -19,7 +20,13 @@ from azure.core.exceptions import (
 )
 from azure.core.rest import HttpRequest
 
-from pydo.agents.custom_sessions import HarnessStreamError, _raise_agents_http_error, _unwrap_harness_sse_chunk
+from pydo.agents.custom_sessions import (
+    _YAML_MEDIA_TYPE,
+    HarnessStreamError,
+    _manifest_bytes,
+    _raise_agents_http_error,
+    _unwrap_harness_sse_chunk,
+)
 from pydo.custom_extensions import AsyncSSEStream, _wrap
 
 _ERROR_MAP = {
@@ -80,6 +87,8 @@ class AsyncSessionsOperations:
         path: str,
         *,
         body: Optional[Dict[str, Any]] = None,
+        content: Optional[Union[str, bytes]] = None,
+        content_type: Optional[str] = None,
         params: Optional[Dict[str, Any]] = None,
         stream: bool = False,
     ):
@@ -92,6 +101,10 @@ class AsyncSessionsOperations:
         if body is not None:
             headers["Content-Type"] = "application/json"
             kwargs["json"] = body
+        elif content is not None:
+            if content_type:
+                headers["Content-Type"] = content_type
+            kwargs["content"] = content
 
         request = HttpRequest(method, path, **kwargs)
         request.url = self._client.format_url(request.url)
@@ -131,20 +144,24 @@ class AsyncSessionsOperations:
             ),
         )
 
-    async def create(
-        self,
-        *,
-        agent_kind: str,
-        repo_hint: Optional[str] = None,
-        idle_timeout_seconds: Optional[int] = None,
-    ) -> Any:
-        body: Dict[str, Any] = {"agent_kind": agent_kind}
-        if repo_hint is not None:
-            body["repo_hint"] = repo_hint
-        if idle_timeout_seconds is not None:
-            body["idle_timeout_seconds"] = idle_timeout_seconds
+    async def create_from_manifest(self, manifest: Union[str, bytes]) -> Any:
+        """Create a session from an ``agents.yaml`` manifest.
+
+        This is the supported creation path: the manifest defines everything
+        about the session (runtime adapter, sandbox, env vars, egress). It is
+        uploaded verbatim as ``application/x-yaml`` and the server owns parsing
+        and validation. There are no ``agent_kind``/``repo_hint`` arguments.
+
+        :param manifest: The agent spec as a YAML ``str`` or ``bytes`` document.
+        """
+        data = _manifest_bytes(manifest)
         return await self._parse_json(
-            await self._send("POST", _BASE_PATH, body=body),
+            await self._send(
+                "POST",
+                _BASE_PATH,
+                content=data,
+                content_type=_YAML_MEDIA_TYPE,
+            ),
         )
 
     async def get(self, session_id: str) -> Any:

--- a/src/pydo/aio/agents/session.py
+++ b/src/pydo/aio/agents/session.py
@@ -1,0 +1,245 @@
+# ------------------------------------
+# Copyright (c) DigitalOcean.
+# Licensed under the Apache-2.0 License.
+# ------------------------------------
+"""Async high-level agent interface (see :mod:`pydo.agents.session`)."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+from pydo.agents.custom_models import ResolutionSource, SessionStatus
+from pydo.agents.session import (
+    AgentEvent,
+    AgentEventType,
+    HITLPolicy,
+    RunResult,
+    _decide_hitl,
+)
+
+
+class AsyncRunStream:
+    """Async iterable of :class:`~pydo.agents.session.AgentEvent` for one run."""
+
+    def __init__(
+        self,
+        *,
+        raw_stream: Any,
+        run_id: Optional[str],
+        session: "AsyncAgentSession",
+        hitl: HITLPolicy = "approve",
+        timeout: Optional[float] = None,
+    ):
+        self._raw = raw_stream
+        self.run_id = run_id
+        self._session = session
+        self._hitl = hitl
+        self._timeout = timeout
+        self._chunks: List[str] = []
+        self.events: List[AgentEvent] = []
+        self.usage: Dict[str, Any] = {}
+        self.status = "running"
+        self.error: Optional[Dict[str, Any]] = None
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        deadline = (
+            (asyncio.get_event_loop().time() + self._timeout) if self._timeout else None
+        )
+        try:
+            async for raw in self._raw:
+                event = AgentEvent(raw)
+                self.events.append(event)
+
+                if event.type == AgentEventType.TOKEN:
+                    self._chunks.append(event.text)
+                elif event.type == AgentEventType.HITL_REQUESTED:
+                    await self._auto_resolve(event)
+
+                yield event
+
+                if self._is_terminal(event):
+                    break
+                if deadline and asyncio.get_event_loop().time() > deadline:
+                    self.status = "timeout"
+                    break
+        finally:
+            await self.close()
+
+    async def _auto_resolve(self, event: AgentEvent) -> None:
+        outcome = _decide_hitl(self._hitl, event)
+        if not outcome or not event.request_id:
+            return
+        try:
+            await self._session.resolve_hitl(
+                event.request_id,
+                outcome=outcome,
+                source=ResolutionSource.OUT_OF_BAND,
+            )
+        except Exception:  # noqa: BLE001 - best-effort; surfaced via the feed
+            pass
+
+    def _is_terminal(self, event: AgentEvent) -> bool:
+        if self.run_id and event.run_id and event.run_id != self.run_id:
+            return False
+        if event.type == AgentEventType.COMPLETED:
+            self.usage = event.usage
+            self.status = "completed"
+            return True
+        if event.type == AgentEventType.FAILED:
+            self.error = event.error
+            self.status = "failed"
+            return True
+        return False
+
+    @property
+    def final_output(self) -> str:
+        return "".join(self._chunks).strip()
+
+    @property
+    def result(self) -> RunResult:
+        return RunResult(
+            run_id=self.run_id,
+            final_output=self.final_output,
+            events=self.events,
+            usage=self.usage,
+            status=self.status,
+            error=self.error,
+        )
+
+    async def close(self) -> None:
+        closer = getattr(self._raw, "close", None)
+        if closer:
+            try:
+                await closer()
+            except Exception:  # noqa: BLE001
+                pass
+
+    async def __aenter__(self) -> "AsyncRunStream":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.close()
+
+
+class AsyncAgentSession:
+    """Async self-managing handle to one hosted-agent session."""
+
+    def __init__(self, sessions: Any, session_id: str, *, raw: Any = None):
+        self._sessions = sessions
+        self.session_id = session_id
+        self._raw = raw
+
+    @property
+    def sessions(self) -> Any:
+        return self._sessions
+
+    @property
+    def info(self) -> Any:
+        raw = self._raw
+        if raw is None:
+            return None
+        get = getattr(raw, "get", None)
+        inner = get("session") if get else None
+        return inner if inner is not None else raw
+
+    @property
+    def status(self) -> Optional[str]:
+        info = self.info
+        get = getattr(info, "get", None)
+        return get("status") if get else None
+
+    async def refresh(self) -> Any:
+        self._raw = await self._sessions.get(self.session_id)
+        return self.info
+
+    async def wait_until_ready(
+        self, *, timeout: float = 120.0, poll_interval: float = 2.0
+    ) -> "AsyncAgentSession":
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + timeout
+        while True:
+            info = await self.refresh()
+            status = (getattr(info, "get", lambda *_: None))("status")
+            if status == SessionStatus.READY:
+                return self
+            if status in (SessionStatus.FAILED, SessionStatus.DESTROYED):
+                raise RuntimeError(f"session {self.session_id} is {status}")
+            if loop.time() > deadline:
+                raise TimeoutError(
+                    f"session {self.session_id} not ready after {timeout}s"
+                )
+            await asyncio.sleep(poll_interval)
+
+    async def run_streamed(
+        self,
+        prompt: str,
+        *,
+        hitl: HITLPolicy = "approve",
+        timeout: Optional[float] = 300.0,
+    ) -> AsyncRunStream:
+        raw_stream = await self._sessions.stream(self.session_id)
+        run = await self._sessions.send_input(self.session_id, text=prompt)
+        run_id = (getattr(run, "get", lambda *_: None))("run_id")
+        return AsyncRunStream(
+            raw_stream=raw_stream,
+            run_id=run_id,
+            session=self,
+            hitl=hitl,
+            timeout=timeout,
+        )
+
+    async def run(
+        self,
+        prompt: str,
+        *,
+        hitl: HITLPolicy = "approve",
+        timeout: Optional[float] = 300.0,
+    ) -> RunResult:
+        stream = await self.run_streamed(prompt, hitl=hitl, timeout=timeout)
+        async for _ in stream:
+            pass
+        return stream.result
+
+    # --- thin passthroughs (session id bound) ---------------------------
+    async def send_input(self, text: str) -> Any:
+        return await self._sessions.send_input(self.session_id, text=text)
+
+    async def stream(self, **kwargs: Any) -> Any:
+        return await self._sessions.stream(self.session_id, **kwargs)
+
+    async def resolve_hitl(
+        self,
+        request_id: str,
+        *,
+        outcome: str,
+        reason: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> None:
+        await self._sessions.resolve_hitl(
+            self.session_id,
+            request_id,
+            outcome=outcome,
+            reason=reason,
+            source=source,
+        )
+
+    async def destroy(self) -> None:
+        await self._sessions.destroy(self.session_id)
+
+    async def __aenter__(self) -> "AsyncAgentSession":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        try:
+            await self.destroy()
+        except Exception:  # noqa: BLE001 - teardown best-effort
+            pass
+
+    def __repr__(self) -> str:
+        return f"AsyncAgentSession(session_id={self.session_id!r})"
+
+
+__all__ = ["AsyncAgentSession", "AsyncRunStream"]

--- a/tests/agents/test_async_sessions.py
+++ b/tests/agents/test_async_sessions.py
@@ -1,0 +1,85 @@
+# pylint: disable=line-too-long,missing-class-docstring,missing-function-docstring,protected-access
+# ------------------------------------
+# Copyright (c) DigitalOcean.
+# Licensed under the Apache-2.0 License.
+# ------------------------------------
+"""Unit tests for :mod:`pydo.aio.agents.custom_sessions`."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any, List
+from unittest.mock import MagicMock
+
+import pytest
+
+from pydo.aio.agents import AsyncAgentsResources
+
+
+class _FakeAsyncResponse:
+    def __init__(self, status_code: int, body: Any = None):
+        self.status_code = status_code
+        if isinstance(body, (dict, list)):
+            self._body_bytes = json.dumps(body).encode("utf-8")
+        elif isinstance(body, str):
+            self._body_bytes = body.encode("utf-8")
+        elif isinstance(body, bytes):
+            self._body_bytes = body
+        else:
+            self._body_bytes = b""
+
+    async def read(self) -> bytes:
+        return self._body_bytes
+
+    def text(self) -> str:
+        return self._body_bytes.decode("utf-8")
+
+    def body(self) -> bytes:
+        return self._body_bytes
+
+
+class _FakeAsyncPipeline:
+    def __init__(self, responses: List[_FakeAsyncResponse]):
+        self._responses = list(responses)
+        self.calls: List[Any] = []
+
+    async def run(self, request, *, stream=False):
+        self.calls.append(SimpleNamespace(request=request, stream=stream))
+        return SimpleNamespace(http_response=self._responses.pop(0))
+
+
+def _make_async_resources(responses: List[_FakeAsyncResponse]) -> AsyncAgentsResources:
+    parent = MagicMock()
+    parent._client = MagicMock()
+    parent._client._pipeline = _FakeAsyncPipeline(responses)
+    return AsyncAgentsResources(
+        parent, agents_endpoint="https://api.stage2.digitalocean.com"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_create_from_manifest_uploads_yaml_verbatim():
+    resources = _make_async_resources(
+        [_FakeAsyncResponse(200, {"session": {"session_id": "abc"}})]
+    )
+    manifest = "apiVersion: agents.digitalocean.com/v1alpha1\nkind: Agent\n"
+
+    resp = await resources.sessions.create_from_manifest(manifest)
+
+    call = resources._proxy._original._pipeline.calls[0]
+    assert call.request.method == "POST"
+    assert call.request.url.endswith("/v2/agents/sessions")
+    assert call.request.headers.get("Content-Type") == "application/x-yaml"
+    content = call.request.content
+    if isinstance(content, bytes):
+        content = content.decode("utf-8")
+    assert content == manifest
+    assert resp.session.session_id == "abc"
+
+
+@pytest.mark.asyncio
+async def test_async_create_from_manifest_rejects_empty():
+    resources = _make_async_resources([])
+    with pytest.raises(ValueError):
+        await resources.sessions.create_from_manifest("")

--- a/tests/agents/test_session_highlevel.py
+++ b/tests/agents/test_session_highlevel.py
@@ -1,0 +1,292 @@
+# pylint: disable=line-too-long,missing-class-docstring,missing-function-docstring,protected-access
+# ------------------------------------
+# Copyright (c) DigitalOcean.
+# Licensed under the Apache-2.0 License.
+# ------------------------------------
+"""Unit tests for the high-level agent interface (:mod:`pydo.agents.session`)."""
+from __future__ import annotations
+
+from typing import Any, List
+
+import pytest
+
+from pydo.agents import AgentEvent, AgentEventType, AgentSession, RunResult
+from pydo.agents.custom_models import HITLOutcome
+from pydo.aio.agents import AsyncAgentSession
+
+
+# ---------------------------------------------------------------------------
+# Sync fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeRawStream:
+    def __init__(self, events: List[dict]):
+        self._events = events
+        self.closed = False
+
+    def __iter__(self):
+        return iter(self._events)
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeSessions:
+    """Stands in for SessionsOperations, recording call order."""
+
+    def __init__(self, events: List[dict]):
+        self._events = events
+        self.calls: List[Any] = []
+        self.resolved: List[Any] = []
+        self.destroyed = False
+
+    def create_from_manifest(self, manifest):
+        self.calls.append(("create", manifest))
+        return {"session": {"session_id": "s1", "status": "SESSION_STATUS_READY"}}
+
+    def stream(self, session_id, **kwargs):
+        self.calls.append(("stream", session_id))
+        return _FakeRawStream(self._events)
+
+    def send_input(self, session_id, *, text):
+        self.calls.append(("send_input", session_id, text))
+        return {"run_id": "r1"}
+
+    def resolve_hitl(
+        self, session_id, request_id, *, outcome, reason=None, source=None
+    ):
+        self.calls.append(("resolve_hitl", session_id, request_id, outcome))
+        self.resolved.append((request_id, outcome))
+
+    def get(self, session_id):
+        return {"session": {"session_id": session_id, "status": "SESSION_STATUS_READY"}}
+
+    def destroy(self, session_id):
+        self.calls.append(("destroy", session_id))
+        self.destroyed = True
+
+
+# ---------------------------------------------------------------------------
+# AgentEvent normalization
+# ---------------------------------------------------------------------------
+
+
+def test_agent_event_normalizes_token():
+    ev = AgentEvent({"type": "run.token_delta", "data": {"text": "hi"}, "run_id": "r1"})
+    assert ev.type == AgentEventType.TOKEN
+    assert ev.text == "hi"
+    assert ev.run_id == "r1"
+
+
+def test_agent_event_normalizes_completed_and_failed():
+    done = AgentEvent({"type": "run.completed", "data": {"total_tokens_out": 7}})
+    assert done.type == AgentEventType.COMPLETED
+    assert done.usage["tokens_out"] == 7
+
+    failed = AgentEvent({"type": "run.failed", "data": {"code": 3, "message": "boom"}})
+    assert failed.type == AgentEventType.FAILED
+    assert failed.error == {"code": 3, "message": "boom"}
+
+
+def test_agent_event_unknown_type_is_other():
+    assert AgentEvent({"type": "session.updated"}).type == AgentEventType.OTHER
+
+
+# ---------------------------------------------------------------------------
+# run / run_streamed
+# ---------------------------------------------------------------------------
+
+
+def test_run_collects_final_output_usage_and_order():
+    events = [
+        {"type": "run.started", "data": {}},
+        {"type": "run.token_delta", "data": {"text": "Hello "}},
+        {"type": "run.token_delta", "data": {"text": "world"}},
+        {
+            "type": "run.completed",
+            "data": {
+                "total_tokens_in": 3,
+                "total_tokens_out": 5,
+                "run_cost_micros": 1234,
+            },
+        },
+    ]
+    sessions = _FakeSessions(events)
+    result = AgentSession(sessions, "s1").run("hi")
+
+    assert isinstance(result, RunResult)
+    assert result.final_output == "Hello world"
+    assert result.status == "completed" and result.ok
+    assert result.usage["tokens_out"] == 5
+    assert result.run_id == "r1"
+    # stream is opened BEFORE input is sent (so no early events are missed)
+    kinds = [c[0] for c in sessions.calls]
+    assert kinds.index("stream") < kinds.index("send_input")
+
+
+def test_run_streamed_yields_typed_events():
+    events = [
+        {"type": "run.token_delta", "data": {"text": "hi"}},
+        {"type": "run.completed", "data": {}},
+    ]
+    stream = AgentSession(_FakeSessions(events), "s1").run_streamed("x")
+    seen = [e.type for e in stream]
+    assert seen == [AgentEventType.TOKEN, AgentEventType.COMPLETED]
+    assert stream.final_output == "hi"
+    assert stream.status == "completed"
+
+
+def test_run_failed_sets_status_and_error():
+    events = [
+        {"type": "run.token_delta", "data": {"text": "partial"}},
+        {"type": "run.failed", "data": {"code": 3, "message": "boom"}},
+    ]
+    result = AgentSession(_FakeSessions(events), "s1").run("x")
+    assert result.status == "failed" and not result.ok
+    assert result.error["message"] == "boom"
+
+
+# ---------------------------------------------------------------------------
+# HITL policy
+# ---------------------------------------------------------------------------
+
+
+def test_run_auto_approves_hitl_by_default():
+    events = [
+        {"type": "run.human_input_requested", "data": {"hitl_id": "req-1"}},
+        {"type": "run.token_delta", "data": {"text": "done"}},
+        {"type": "run.completed", "data": {}},
+    ]
+    sessions = _FakeSessions(events)
+    result = AgentSession(sessions, "s1").run("do it")
+    assert ("req-1", HITLOutcome.APPROVE) in sessions.resolved
+    assert result.final_output == "done"
+
+
+def test_hitl_callable_policy_receives_event():
+    events = [
+        {"type": "run.human_input_requested", "data": {"hitl_id": "req-9"}},
+        {"type": "run.completed", "data": {}},
+    ]
+    sessions = _FakeSessions(events)
+    seen = []
+
+    def policy(event):
+        seen.append(event.request_id)
+        return "reject"
+
+    AgentSession(sessions, "s1").run("x", hitl=policy)
+    assert seen == ["req-9"]
+    assert ("req-9", HITLOutcome.REJECT) in sessions.resolved
+
+
+def test_hitl_none_leaves_prompt_unresolved():
+    events = [
+        {"type": "run.human_input_requested", "data": {"hitl_id": "req-9"}},
+        {"type": "run.completed", "data": {}},
+    ]
+    sessions = _FakeSessions(events)
+    AgentSession(sessions, "s1").run("x", hitl=None)
+    assert sessions.resolved == []
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_context_manager_destroys():
+    sessions = _FakeSessions([])
+    with AgentSession(sessions, "s1") as agent:
+        assert agent.session_id == "s1"
+    assert sessions.destroyed
+
+
+def test_run_stream_closes_underlying_stream():
+    events = [{"type": "run.completed", "data": {}}]
+    sessions = _FakeSessions(events)
+    stream = AgentSession(sessions, "s1").run_streamed("x")
+    raw = stream._raw
+    list(stream)
+    assert raw.closed
+
+
+# ---------------------------------------------------------------------------
+# Async parity
+# ---------------------------------------------------------------------------
+
+
+class _FakeAsyncRawStream:
+    def __init__(self, events: List[dict]):
+        self._events = events
+        self.closed = False
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        for ev in self._events:
+            yield ev
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeAsyncSessions:
+    def __init__(self, events: List[dict]):
+        self._events = events
+        self.calls: List[Any] = []
+        self.resolved: List[Any] = []
+        self.destroyed = False
+
+    async def stream(self, session_id, **kwargs):
+        self.calls.append(("stream", session_id))
+        return _FakeAsyncRawStream(self._events)
+
+    async def send_input(self, session_id, *, text):
+        self.calls.append(("send_input", session_id, text))
+        return {"run_id": "r1"}
+
+    async def resolve_hitl(
+        self, session_id, request_id, *, outcome, reason=None, source=None
+    ):
+        self.resolved.append((request_id, outcome))
+
+    async def destroy(self, session_id):
+        self.destroyed = True
+
+
+@pytest.mark.asyncio
+async def test_async_run_collects_output_and_order():
+    events = [
+        {"type": "run.token_delta", "data": {"text": "Hi "}},
+        {"type": "run.token_delta", "data": {"text": "there"}},
+        {"type": "run.completed", "data": {"total_tokens_out": 2}},
+    ]
+    sessions = _FakeAsyncSessions(events)
+    result = await AsyncAgentSession(sessions, "s1").run("x")
+    assert result.final_output == "Hi there"
+    assert result.status == "completed"
+    assert result.usage["tokens_out"] == 2
+    kinds = [c[0] for c in sessions.calls]
+    assert kinds.index("stream") < kinds.index("send_input")
+
+
+@pytest.mark.asyncio
+async def test_async_auto_approves_hitl():
+    events = [
+        {"type": "run.human_input_requested", "data": {"hitl_id": "req-1"}},
+        {"type": "run.completed", "data": {}},
+    ]
+    sessions = _FakeAsyncSessions(events)
+    await AsyncAgentSession(sessions, "s1").run("x")
+    assert ("req-1", HITLOutcome.APPROVE) in sessions.resolved
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_destroys():
+    sessions = _FakeAsyncSessions([])
+    async with AsyncAgentSession(sessions, "s1") as agent:
+        assert agent.session_id == "s1"
+    assert sessions.destroyed

--- a/tests/agents/test_sessions.py
+++ b/tests/agents/test_sessions.py
@@ -4,6 +4,7 @@
 # Licensed under the Apache-2.0 License.
 # ------------------------------------
 """Unit tests for :mod:`pydo.agents.custom_sessions`."""
+
 from __future__ import annotations
 
 import json
@@ -14,7 +15,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from pydo.agents import (
-    AgentKind,
     AgentsResources,
     HITLOutcome,
     HarnessStreamError,
@@ -23,7 +23,6 @@ from pydo.agents import (
     SessionStatus,
     resolve_agents_base_url,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fake pipeline / response plumbing
@@ -85,26 +84,41 @@ def _make_resources(responses: List[_FakeResponse]) -> AgentsResources:
 # ---------------------------------------------------------------------------
 
 
-def test_create_session_posts_expected_body():
+def test_create_from_manifest_uploads_yaml_verbatim():
     body = {"session": {"session_id": "abc", "status": SessionStatus.PROVISIONING}}
     resources = _make_resources([_FakeResponse(200, body)])
 
-    resp = resources.sessions.create(
-        agent_kind=AgentKind.CLAUDE_CODE,
-        repo_hint="digitalocean/pydo",
-        idle_timeout_seconds=900,
+    manifest = (
+        "apiVersion: agents.digitalocean.com/v1alpha1\n"
+        "kind: Agent\n"
+        "metadata:\n"
+        "  name: harness-demo\n"
     )
+    resp = resources.sessions.create_from_manifest(manifest)
 
     call = resources._proxy._original._pipeline.calls[0]
     assert call.request.method == "POST"
     assert call.request.url.endswith("/v2/agents/sessions")
-    sent = json.loads(call.request.content)
-    assert sent == {
-        "agent_kind": "AGENT_KIND_CLAUDE_CODE",
-        "repo_hint": "digitalocean/pydo",
-        "idle_timeout_seconds": 900,
-    }
+    assert call.request.headers.get("Content-Type") == "application/x-yaml"
+    content = call.request.content
+    if isinstance(content, bytes):
+        content = content.decode("utf-8")
+    assert content == manifest
     assert resp.session.session_id == "abc"
+
+
+def test_create_from_manifest_accepts_bytes():
+    resources = _make_resources([_FakeResponse(200, {"session": {"session_id": "z"}})])
+    resources.sessions.create_from_manifest(b"kind: Agent\n")
+
+    call = resources._proxy._original._pipeline.calls[0]
+    assert call.request.headers.get("Content-Type") == "application/x-yaml"
+
+
+def test_create_from_manifest_rejects_empty():
+    resources = _make_resources([])
+    with pytest.raises(ValueError):
+        resources.sessions.create_from_manifest("   \n  ")
 
 
 def test_get_session_url_encodes_id():


### PR DESCRIPTION
## Summary

Builds on the Harness (`/v2/agents`) integration to align hosted-agent session
creation with the real backend contract and to make the surface idiomatic for
SDK users. Two parts:

1. **Spec/manifest-based session creation.** The harness-api backend provisions
   a session entirely from an `agents.yaml` manifest, so the legacy JSON
   `create(agent_kind=…)` path is replaced with `create_from_manifest()`, which
   uploads the spec verbatim as `Content-Type: application/x-yaml`. The manifest
   defines the runtime adapter, sandbox, env vars, and egress — there are no
   other arguments.

2. **High-level `AgentSession` interface**.
   Wraps the low-level session/SSE operations so consuming a run needs no manual
   wiring — no background thread, no dispatching on raw `run.*` event strings,
   no manual teardown.

Both parts ship with full sync **and** async parity. The low-level
`client.agents.sessions.*` operations are unchanged for callers who want raw
control.

## What's new

### Session creation from a spec
- `client.agents.sessions.create_from_manifest(manifest: str | bytes)` →
  `POST /v2/agents/sessions` as `application/x-yaml`.
- Removed the unsupported `create(agent_kind=…)` JSON path.

### High-level agent interface
- `client.agents.start(manifest)` → `AgentSession` (create from spec)
- `client.agents.attach(session_id)` → `AgentSession` (existing session)
- `AgentSession.run(prompt)` → blocking; returns `RunResult`
  (`.final_output`, `.usage`, `.status`, `.ok`, `.events`, `.error`)
- `AgentSession.run_streamed(prompt)` → iterable `RunStream` of normalized
  `AgentEvent`s; exposes `.final_output` / `.usage` / `.result` afterward
- Normalized `AgentEventType` (TOKEN, RUN_STARTED, TOOL_CALL, TOOL_RESULT,
  HITL_REQUESTED, HITL_RESOLVED, COMPLETED, FAILED, OTHER) with typed accessors
  (`.text`, `.tool_name`, `.request_id`, `.usage`, `.error`) and `.raw`
- Built-in HITL handling via a `hitl=` policy (`"approve"` default,
  `"reject"`/`"defer"`, a callable `event -> decision`, or `None` to defer to
  the caller)
- Opens the stream before sending input (no early events missed); context
  manager auto-destroys the session on exit

### Before / after (consuming a run)

Before: manually spawn a reader thread, coordinate a completion `Event`,
dispatch on raw `run.token_delta`/`run.completed` strings, accumulate tokens,
call `resolve_hitl`, and `destroy` by hand. After:

    with client.agents.start(manifest) as agent:          # create + auto-destroy
        for event in agent.run_streamed("Summarize the repo"):
            if event.type == AgentEventType.TOKEN:
                print(event.text, end="")
        print(agent.run("and now add tests").final_output)  # blocking one-liner

### doctl `agents` parity

| doctl verb | pydo |
| --- | --- |
| start   | `agents.start(manifest)` / `sessions.create_from_manifest` |
| show    | `sessions.get` / `AgentSession.refresh` / `.info` |
| list    | `sessions.list` |
| destroy | `sessions.destroy` / `AgentSession.destroy` |
| approve | `sessions.resolve_hitl(source=OUT_OF_BAND)` / `hitl=` policy |
| attach  | `agents.attach(id)` + `run_streamed` / `run` |
| logs    | `sessions.stream(replay_only=True)` |

### Examples
- `examples/agents/session_e2e.py` — rewritten on the high-level API
- `examples/agents/attach.py` — attach to an existing session and stream a turn
- `examples/agents/run_blocking.py` — blocking one-liner
- `examples/agents/create_session.py` — updated to the manifest path

## Testing
- `tests/agents/` — **30 passing** (sync + async): manifest upload, event
  normalization, output/usage assembly, stream-before-input ordering, HITL
  policies, failure handling, context-manager teardown. `black` clean.
- Manually verified end-to-end against **stage2 (s2r1)** with a real codex-cli
  agent spec: `create_from_manifest` → stream → `send_input` → HITL resolve →
  `destroy`, plus the high-level `start` / `attach` / `run` / `run_streamed`
  flows. The agent produced correct streamed replies.

## Notes
- `attach` provides programmatic streaming, not doctl's interactive TUI.
- Example docstrings reference an internal stage2 hostname; consider scrubbing
  before any public release.
- `run.completed` reports zeroed token usage on stage2 (server-side reporting
  detail, not an SDK issue).

## Test plan
- [ ] `make test-mocked`
- [ ] Manual e2e on stage2 with a real agent spec (start → attach/run → destroy)