### PR TITLE
MARSOHS-884 - agents: verify spec.skills passthrough and error surfacing

### DIFF
--- a/examples/agents/create_session_with_skills.py
+++ b/examples/agents/create_session_with_skills.py
@@ -1,0 +1,54 @@
+"""Create a session from a manifest that includes ``spec.skills``.
+
+A skill is an inline Agent Skill in the ``SKILL.md`` shape: ``name`` and
+``description``/``instructions`` are required, ``license``/``metadata`` and
+``allowedTools`` are optional. Skills are advisory scoping only, not
+enforcement — ``spec.permissions`` is still the real tool-call enforcement
+surface.
+
+There is no typed ``Skill`` model in pydo — like the rest of the manifest,
+``spec.skills`` is authored as plain YAML and uploaded verbatim
+(``Content-Type: application/x-yaml``); harness-api owns all parsing and
+validation, including rejecting a ``spec.skills`` list that would encode too
+large for the sandbox's ``HARNESS_SKILLS`` env var. That error surfaces as a
+normal ``azure.core.exceptions.HttpResponseError`` with a readable message —
+no special handling needed on the client side.
+
+Required env:
+  DIGITALOCEAN_TOKEN
+  PYDO_AGENTS_ENDPOINT  (stage2: https://api.s2r1.internal.digitalocean.com)
+"""
+
+import json
+import os
+
+from azure.core.exceptions import HttpResponseError
+
+from pydo import Client
+
+manifest = """\
+apiVersion: agents.digitalocean.com/v1alpha1
+kind: Agent
+metadata:
+  name: harness-demo
+spec:
+  skills:
+    - name: release-notes
+      description: Draft release notes from a diff.
+      instructions: |
+        Summarize the diff in Keep a Changelog format.
+        Group entries under Added/Changed/Fixed.
+"""
+
+client = Client(
+    token=os.environ["DIGITALOCEAN_TOKEN"],
+    agents_endpoint=os.environ.get("PYDO_AGENTS_ENDPOINT"),
+)
+
+try:
+    resp = client.agents.sessions.create_from_manifest(manifest)
+except HttpResponseError as err:
+    print(f"session create failed: {err.message}")
+    raise
+
+print(json.dumps(resp, indent=2, default=str))

--- a/tests/agents/test_sessions.py
+++ b/tests/agents/test_sessions.py
@@ -13,6 +13,7 @@ from typing import Any, List
 from unittest.mock import MagicMock
 
 import pytest
+from azure.core.exceptions import HttpResponseError
 
 from pydo.agents import (
     AgentsResources,
@@ -30,8 +31,11 @@ from pydo.agents import (
 
 
 class _FakeResponse:
-    def __init__(self, status_code: int, body: Any = None, *, sse_chunks=None):
+    def __init__(
+        self, status_code: int, body: Any = None, *, sse_chunks=None, reason: str = ""
+    ):
         self.status_code = status_code
+        self.reason = reason
         if isinstance(body, (dict, list)):
             self._body_bytes = json.dumps(body).encode("utf-8")
         elif isinstance(body, str):
@@ -119,6 +123,58 @@ def test_create_from_manifest_rejects_empty():
     resources = _make_resources([])
     with pytest.raises(ValueError):
         resources.sessions.create_from_manifest("   \n  ")
+
+
+def test_create_from_manifest_preserves_multiline_skill_instructions():
+    # spec.skills is forwarded raw, like the rest of the manifest — no client-side
+    # parsing/re-marshaling happens, so a multi-line `instructions` block scalar
+    # must survive byte-for-byte.
+    body = {"session": {"session_id": "abc", "status": SessionStatus.PROVISIONING}}
+    resources = _make_resources([_FakeResponse(200, body)])
+
+    manifest = (
+        "apiVersion: agents.digitalocean.com/v1alpha1\n"
+        "kind: Agent\n"
+        "metadata:\n"
+        "  name: harness-demo\n"
+        "spec:\n"
+        "  skills:\n"
+        "    - name: release-notes\n"
+        "      description: Draft release notes from a diff.\n"
+        "      instructions: |\n"
+        "        Summarize the diff in Keep a Changelog format.\n"
+        "        Group entries under Added/Changed/Fixed.\n"
+    )
+    resources.sessions.create_from_manifest(manifest)
+
+    call = resources._proxy._original._pipeline.calls[0]
+    content = call.request.content
+    if isinstance(content, bytes):
+        content = content.decode("utf-8")
+    assert content == manifest
+
+
+def test_create_from_manifest_surfaces_skills_size_cap_error():
+    # harness-api rejects an oversized spec.skills list with a nested
+    # {"error": {"code", "message"}} envelope. azure-core's OData-v4 error
+    # parsing already extracts a clean message from this shape — no SDK
+    # code change needed, this just proves it.
+    message = (
+        "agentspec: spec.skills would encode to 70000 bytes as the "
+        "HARNESS_SKILLS guest env value, exceeding the sandbox's 65536-byte "
+        "limit; trim instructions/descriptions or reduce the number of "
+        "skills (temporary limit while skill delivery rides an env var)"
+    )
+    body = {"error": {"code": 400, "message": message}}
+    resources = _make_resources([_FakeResponse(400, body, reason="Bad Request")])
+
+    with pytest.raises(HttpResponseError) as exc_info:
+        resources.sessions.create_from_manifest("kind: Agent\nspec:\n  skills: []\n")
+
+    error_text = str(exc_info.value)
+    assert message in error_text
+    assert '{"error"' not in error_text
+    assert '{"message"' not in error_text
 
 
 def test_get_session_url_encodes_id():


### PR DESCRIPTION
## Summary
- `spec.skills` on the Agent manifest is authored as plain YAML and forwarded verbatim, matching `doctl`'s approach — no typed `Skill` model is added, keeping `pydo` consistent across the P1 authoring clients.
- Adds regression coverage proving a multi-line `instructions` block scalar under `spec.skills` survives `create_from_manifest`'s raw passthrough byte-for-byte.
- Adds regression coverage proving harness-api's skills size-cap error (`HARNESS_SKILLS` env-var limit) surfaces as a clean, readable `HttpResponseError` message, with no raw JSON leaking through.
- Adds an example (`examples/agents/create_session_with_skills.py`) showing how to author a manifest with `spec.skills`.

No changes to `src/pydo/agents/*.py` — the existing raw-YAML passthrough and generic error handling already do the right thing for skills; this PR is verification + docs.

Ref: MARSOHS-884

## Test plan
- [x] `pytest tests/agents/` (99 tests) passes
- [x] `black --check` clean on the touched test file
- [x] New example script compiles (`python -m py_compile`)