### PR TITLE
agents: let trigger rotate_secret revoke the outgoing webhook secret (MARSOHS-1078)

### DIFF
--- a/src/pydo/agents/custom_triggers.py
+++ b/src/pydo/agents/custom_triggers.py
@@ -157,16 +157,25 @@ class TriggersOperations:
         """
         self._send("DELETE", f"{_TRIGGERS_PATH}/{_quote(trigger_id)}")
 
-    def rotate_secret(self, trigger_id: str) -> Any:
+    def rotate_secret(self, trigger_id: str, *, revoke_previous: bool = False) -> Any:
         """Issue a new webhook secret (``POST .../{id}/rotate-secret``).
 
-        Webhook triggers only (``409`` for cron). The new secret is shown
-        once; the previous value stays valid briefly for in-flight deliveries.
+        Webhook triggers only (``409`` for cron). The new secret is shown once.
+
+        By default the outgoing secret keeps verifying deliveries for a short
+        server-configured window, because the provider signs with the old value
+        until someone pastes the new one in, and ``previous_secret_expires_at``
+        in the response says when it dies. Pass ``revoke_previous=True`` to
+        retire it on this call instead — intended for a compromised secret,
+        since deliveries still signed with the old value fail immediately, and
+        the response then carries ``previous_secret_revoked`` instead of an
+        expiry. Exactly one of the two is present.
         """
         return self._parse_json(
             self._send(
                 "POST",
                 f"{_TRIGGERS_PATH}/{_quote(trigger_id)}/rotate-secret",
+                params={"revoke_previous": "true" if revoke_previous else None},
             ),
         )
 

--- a/src/pydo/aio/agents/custom_triggers.py
+++ b/src/pydo/aio/agents/custom_triggers.py
@@ -120,12 +120,19 @@ class AsyncTriggersOperations:
         """Soft-delete a trigger (``DELETE /v2/agents/triggers/{id}``)."""
         await self._send("DELETE", f"{_TRIGGERS_PATH}/{_quote(trigger_id)}")
 
-    async def rotate_secret(self, trigger_id: str) -> Any:
-        """Issue a new webhook secret (shown once)."""
+    async def rotate_secret(
+        self, trigger_id: str, *, revoke_previous: bool = False
+    ) -> Any:
+        """Issue a new webhook secret (shown once).
+
+        The outgoing secret keeps verifying deliveries for a short grace window
+        unless ``revoke_previous=True`` retires it on this call.
+        """
         return await self._parse_json(
             await self._send(
                 "POST",
                 f"{_TRIGGERS_PATH}/{_quote(trigger_id)}/rotate-secret",
+                params={"revoke_previous": "true" if revoke_previous else None},
             ),
         )
 

--- a/src/pydo/aio/agents/custom_triggers.py
+++ b/src/pydo/aio/agents/custom_triggers.py
@@ -123,10 +123,18 @@ class AsyncTriggersOperations:
     async def rotate_secret(
         self, trigger_id: str, *, revoke_previous: bool = False
     ) -> Any:
-        """Issue a new webhook secret (shown once).
+        """Issue a new webhook secret (``POST .../{id}/rotate-secret``).
 
-        The outgoing secret keeps verifying deliveries for a short grace window
-        unless ``revoke_previous=True`` retires it on this call.
+        Webhook triggers only (``409`` for cron). The new secret is shown once.
+
+        By default the outgoing secret keeps verifying deliveries for a short
+        server-configured window, because the provider signs with the old value
+        until someone pastes the new one in, and ``previous_secret_expires_at``
+        in the response says when it dies. Pass ``revoke_previous=True`` to
+        retire it on this call instead — intended for a compromised secret,
+        since deliveries still signed with the old value fail immediately, and
+        the response then carries ``previous_secret_revoked`` instead of an
+        expiry. Exactly one of the two is present.
         """
         return await self._parse_json(
             await self._send(

--- a/tests/agents/test_async_triggers.py
+++ b/tests/agents/test_async_triggers.py
@@ -59,6 +59,19 @@ def _make_async_resources(responses: List[_FakeAsyncResponse]) -> AsyncAgentsRes
     )
 
 
+def _find_call(resources: AsyncAgentsResources, path_suffix: str):
+    """Return the single recorded call whose URL path ends with path_suffix."""
+    matches = [
+        c
+        for c in resources._proxy._original._pipeline.calls
+        if c.request.url.split("?")[0].endswith(path_suffix)
+    ]
+    assert (
+        len(matches) == 1
+    ), f"expected exactly one {path_suffix} call, got {len(matches)}"
+    return matches[0]
+
+
 @pytest.mark.asyncio
 async def test_async_list_and_create_triggers():
     resources = _make_async_resources(
@@ -130,10 +143,11 @@ async def test_async_update_delete_rotate_and_executions():
 
     rotated = await resources.triggers.rotate_secret("t1")
     assert rotated.webhook_secret == "new"
-    assert (
-        "revoke_previous"
-        not in resources._proxy._original._pipeline.calls[2].request.url
-    )
+    # Located by URL rather than by index: this test walks a fixed sequence of
+    # calls, and a positional assertion silently starts checking someone else's
+    # request the moment a call is inserted above.
+    rotate_call = _find_call(resources, "/rotate-secret")
+    assert "revoke_previous" not in rotate_call.request.url
 
     executions = await resources.triggers.list_executions("t1")
     assert executions.executions[0].execution_id == "e1"

--- a/tests/agents/test_async_triggers.py
+++ b/tests/agents/test_async_triggers.py
@@ -130,6 +130,10 @@ async def test_async_update_delete_rotate_and_executions():
 
     rotated = await resources.triggers.rotate_secret("t1")
     assert rotated.webhook_secret == "new"
+    assert (
+        "revoke_previous"
+        not in resources._proxy._original._pipeline.calls[2].request.url
+    )
 
     executions = await resources.triggers.list_executions("t1")
     assert executions.executions[0].execution_id == "e1"
@@ -152,3 +156,21 @@ async def test_async_update_delete_rotate_and_executions():
     assert resources._proxy._original._pipeline.calls[7].request.url.endswith(
         "/v2/agents/webhook-providers"
     )
+
+
+@pytest.mark.asyncio
+async def test_async_rotate_secret_revoke_previous():
+    resources = _make_async_resources(
+        [
+            _FakeAsyncResponse(
+                200, {"webhook_secret": "new", "previous_secret_revoked": True}
+            )
+        ]
+    )
+
+    rotated = await resources.triggers.rotate_secret("t1", revoke_previous=True)
+
+    call = resources._proxy._original._pipeline.calls[0]
+    assert call.request.method == "POST"
+    assert "revoke_previous=true" in call.request.url
+    assert rotated.previous_secret_revoked is True

--- a/tests/agents/test_triggers.py
+++ b/tests/agents/test_triggers.py
@@ -197,7 +197,10 @@ def test_delete_trigger_returns_none_on_204():
 
 
 def test_rotate_secret():
-    body = {"webhook_secret": "whsec_rotated"}
+    body = {
+        "webhook_secret": "whsec_rotated",
+        "previous_secret_expires_at": "2026-07-01T12:05:00Z",
+    }
     resources = _make_resources([_FakeResponse(200, body)])
 
     resp = resources.triggers.rotate_secret("t1")
@@ -205,7 +208,22 @@ def test_rotate_secret():
     call = _last_call(resources)
     assert call.request.method == "POST"
     assert call.request.url.endswith("/v2/agents/triggers/t1/rotate-secret")
+    assert "revoke_previous" not in call.request.url
     assert resp.webhook_secret == "whsec_rotated"
+    assert resp.previous_secret_expires_at == "2026-07-01T12:05:00Z"
+
+
+def test_rotate_secret_revoke_previous():
+    body = {"webhook_secret": "whsec_rotated", "previous_secret_revoked": True}
+    resources = _make_resources([_FakeResponse(200, body)])
+
+    resp = resources.triggers.rotate_secret("t1", revoke_previous=True)
+
+    call = _last_call(resources)
+    assert call.request.method == "POST"
+    assert _path(call.request.url).endswith("/v2/agents/triggers/t1/rotate-secret")
+    assert "revoke_previous=true" in call.request.url
+    assert resp.previous_secret_revoked is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`triggers.rotate_secret()` can only ask for the default rotation, and its docstring says the old secret "stays valid briefly" — which is exactly the unactionable wording MARSOHS-1078 was filed about. Someone responding to a leaked secret can neither kill the old value nor tell from the response whether it is already dead.

This adds `revoke_previous` to the sync and async clients. The default is unchanged.

```python
# routine rotation: grace window, unchanged behaviour
resp = client.agents.triggers.rotate_secret("trig-abc123")
resp.previous_secret_expires_at   # when the old secret stops verifying

# breach response: retire the outgoing secret on this call
resp = client.agents.triggers.rotate_secret("trig-abc123", revoke_previous=True)
resp.previous_secret_revoked      # True; no expiry is reported
```

Why grace is still the default: the provider side holds one secret at a time (a GitHub webhook has a single `Secret` field), so it keeps signing with the old value until a human pastes the new one in. Revoking on every rotate would turn routine rotation into a delivery outage lasting as long as that handoff. `revoke_previous=True` accepts that gap deliberately, because a leaked secret is the worse risk.

The response now always states the outcome — exactly one of `previous_secret_expires_at` and `previous_secret_revoked` is present, so a caller never infers it from a missing field. The docstrings were rewritten to say so.

## Notes for review

- Purely additive: `revoke_previous` is keyword-only and defaults to `False`.
- No Autorest regen. This is the hand-authored `custom_triggers.py` surface, so nothing here depends on an openapi publish — unlike #699 / #708, there is no `DO_OPENAPI_COMMIT_SHA.txt` bump to wait on.
- The shared `_send` helper already drops `None` params, so the default rotate puts no query parameter on the wire at all. Both suites assert that rather than only asserting the revoke case.
- Based on `OHS_endpoints`, matching #708 — so #680 picks this up when it carries the branch to `main`.

## Related

- Server side: `digitalocean/cthulhu#172453` (harness-trigger — `?revoke_previous=true`, plus a cleaner sweep that nulls the expired ciphertext once the window closes).
- godo: digitalocean/godo#1092 (same change, also on `OHS_endpoints`).
- doctl: digitalocean/doctl#1922 (`doctl agents triggers rotate-secret --revoke-previous`).

## Test plan

- [x] `pytest tests/agents/` — 127 passed, 1 skipped (pre-existing)
- [x] New: `test_rotate_secret_revoke_previous` and `test_async_rotate_secret_revoke_previous` assert `revoke_previous=true` reaches the wire and the revoked flag parses
- [x] Existing `test_rotate_secret` extended to assert the default sends **no** `revoke_previous` and parses the expiry
- [x] `black --check` clean

Made with [Cursor](https://cursor.com)