### PR TITLE
agents: replace revoke_previous with grace_period_seconds (MARSOHS-1078)

### DIFF
--- a/src/pydo/agents/custom_triggers.py
+++ b/src/pydo/agents/custom_triggers.py
@@ -157,25 +157,28 @@ class TriggersOperations:
         """
         self._send("DELETE", f"{_TRIGGERS_PATH}/{_quote(trigger_id)}")
 
-    def rotate_secret(self, trigger_id: str, *, revoke_previous: bool = False) -> Any:
+    def rotate_secret(
+        self, trigger_id: str, *, grace_period_seconds: Optional[int] = None
+    ) -> Any:
         """Issue a new webhook secret (``POST .../{id}/rotate-secret``).
 
         Webhook triggers only (``409`` for cron). The new secret is shown once.
 
-        By default the outgoing secret keeps verifying deliveries for a short
-        server-configured window, because the provider signs with the old value
-        until someone pastes the new one in, and ``previous_secret_expires_at``
-        in the response says when it dies. Pass ``revoke_previous=True`` to
+        By default (``grace_period_seconds`` omitted) the outgoing secret keeps
+        verifying deliveries for 5 minutes, and ``previous_secret_expires_at``
+        in the response says when it dies. Pass ``grace_period_seconds=0`` to
         retire it on this call instead — intended for a compromised secret,
         since deliveries still signed with the old value fail immediately, and
         the response then carries ``previous_secret_revoked`` instead of an
-        expiry. Exactly one of the two is present.
+        expiry. A positive value sets a custom handoff window (server max
+        default 1 hour; above the max is ``400``). Exactly one of the two
+        outcome fields is present.
         """
         return self._parse_json(
             self._send(
                 "POST",
                 f"{_TRIGGERS_PATH}/{_quote(trigger_id)}/rotate-secret",
-                params={"revoke_previous": "true" if revoke_previous else None},
+                params={"grace_period_seconds": grace_period_seconds},
             ),
         )
 

--- a/src/pydo/aio/agents/custom_triggers.py
+++ b/src/pydo/aio/agents/custom_triggers.py
@@ -121,26 +121,27 @@ class AsyncTriggersOperations:
         await self._send("DELETE", f"{_TRIGGERS_PATH}/{_quote(trigger_id)}")
 
     async def rotate_secret(
-        self, trigger_id: str, *, revoke_previous: bool = False
+        self, trigger_id: str, *, grace_period_seconds: Optional[int] = None
     ) -> Any:
         """Issue a new webhook secret (``POST .../{id}/rotate-secret``).
 
         Webhook triggers only (``409`` for cron). The new secret is shown once.
 
-        By default the outgoing secret keeps verifying deliveries for a short
-        server-configured window, because the provider signs with the old value
-        until someone pastes the new one in, and ``previous_secret_expires_at``
-        in the response says when it dies. Pass ``revoke_previous=True`` to
+        By default (``grace_period_seconds`` omitted) the outgoing secret keeps
+        verifying deliveries for 5 minutes, and ``previous_secret_expires_at``
+        in the response says when it dies. Pass ``grace_period_seconds=0`` to
         retire it on this call instead — intended for a compromised secret,
         since deliveries still signed with the old value fail immediately, and
         the response then carries ``previous_secret_revoked`` instead of an
-        expiry. Exactly one of the two is present.
+        expiry. A positive value sets a custom handoff window (server max
+        default 1 hour; above the max is ``400``). Exactly one of the two
+        outcome fields is present.
         """
         return await self._parse_json(
             await self._send(
                 "POST",
                 f"{_TRIGGERS_PATH}/{_quote(trigger_id)}/rotate-secret",
-                params={"revoke_previous": "true" if revoke_previous else None},
+                params={"grace_period_seconds": grace_period_seconds},
             ),
         )
 

--- a/tests/agents/test_async_triggers.py
+++ b/tests/agents/test_async_triggers.py
@@ -147,7 +147,7 @@ async def test_async_update_delete_rotate_and_executions():
     # calls, and a positional assertion silently starts checking someone else's
     # request the moment a call is inserted above.
     rotate_call = _find_call(resources, "/rotate-secret")
-    assert "revoke_previous" not in rotate_call.request.url
+    assert "grace_period_seconds" not in rotate_call.request.url
 
     executions = await resources.triggers.list_executions("t1")
     assert executions.executions[0].execution_id == "e1"
@@ -173,7 +173,7 @@ async def test_async_update_delete_rotate_and_executions():
 
 
 @pytest.mark.asyncio
-async def test_async_rotate_secret_revoke_previous():
+async def test_async_rotate_secret_zero_grace():
     resources = _make_async_resources(
         [
             _FakeAsyncResponse(
@@ -182,9 +182,9 @@ async def test_async_rotate_secret_revoke_previous():
         ]
     )
 
-    rotated = await resources.triggers.rotate_secret("t1", revoke_previous=True)
+    rotated = await resources.triggers.rotate_secret("t1", grace_period_seconds=0)
 
     call = resources._proxy._original._pipeline.calls[0]
     assert call.request.method == "POST"
-    assert "revoke_previous=true" in call.request.url
+    assert "grace_period_seconds=0" in call.request.url
     assert rotated.previous_secret_revoked is True

--- a/tests/agents/test_triggers.py
+++ b/tests/agents/test_triggers.py
@@ -208,22 +208,36 @@ def test_rotate_secret():
     call = _last_call(resources)
     assert call.request.method == "POST"
     assert call.request.url.endswith("/v2/agents/triggers/t1/rotate-secret")
-    assert "revoke_previous" not in call.request.url
+    assert "grace_period_seconds" not in call.request.url
     assert resp.webhook_secret == "whsec_rotated"
     assert resp.previous_secret_expires_at == "2026-07-01T12:05:00Z"
 
 
-def test_rotate_secret_revoke_previous():
+def test_rotate_secret_zero_grace():
     body = {"webhook_secret": "whsec_rotated", "previous_secret_revoked": True}
     resources = _make_resources([_FakeResponse(200, body)])
 
-    resp = resources.triggers.rotate_secret("t1", revoke_previous=True)
+    resp = resources.triggers.rotate_secret("t1", grace_period_seconds=0)
 
     call = _last_call(resources)
     assert call.request.method == "POST"
     assert _path(call.request.url).endswith("/v2/agents/triggers/t1/rotate-secret")
-    assert "revoke_previous=true" in call.request.url
+    assert "grace_period_seconds=0" in call.request.url
     assert resp.previous_secret_revoked is True
+
+
+def test_rotate_secret_custom_grace():
+    body = {
+        "webhook_secret": "whsec_rotated",
+        "previous_secret_expires_at": "2026-07-01T12:01:30Z",
+    }
+    resources = _make_resources([_FakeResponse(200, body)])
+
+    resp = resources.triggers.rotate_secret("t1", grace_period_seconds=90)
+
+    call = _last_call(resources)
+    assert "grace_period_seconds=90" in call.request.url
+    assert resp.previous_secret_expires_at == "2026-07-01T12:01:30Z"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replaces `revoke_previous: bool` with `grace_period_seconds: Optional[int] = None` on sync and async `rotate_secret`, matching the server contract in cthulhu#172453.

| Call | Wire | Outcome |
|---|---|---|
| omitted / `None` | no query param | server 5m default |
| `0` | `grace_period_seconds=0` | immediate revoke |
| `N` | `grace_period_seconds=N` | custom window (server max 1h) |

## Related

- Server: digitalocean/cthulhu#172453
- godo: digitalocean/godo#1093
- doctl: digitalocean/doctl#1932

## Test plan

- [x] `pytest tests/agents/test_triggers.py tests/agents/test_async_triggers.py` — 20 passed

Made with [Cursor](https://cursor.com)