### PR TITLE
agents: expose session create warnings (MARSOHS-1019)

### DIFF
--- a/src/pydo/agents/__init__.py
+++ b/src/pydo/agents/__init__.py
@@ -35,6 +35,8 @@ from .custom_sessions import (
     SessionsOperations,
     WorkspaceDownload,
     WorkspaceTransferError,
+    emit_session_create_warnings,
+    session_create_warnings,
 )
 from .custom_configs import ConfigsOperations
 from .custom_triggers import TriggersOperations
@@ -150,6 +152,8 @@ class AgentsResources:
             resolved,
             openai_session_id=oai_session_id,
         )
+        # Mirror doctl: surface create-time advisories (policy fidelity, etc.).
+        emit_session_create_warnings(session_create_warnings(resp), stacklevel=2)
         get = getattr(resp, "get", None)
         info = get("session") if get else None
         session_id = (getattr(info or resp, "get", lambda *_: None))("session_id")
@@ -222,6 +226,8 @@ __all__ = [
     "HistoryPage",
     "WorkspaceDownload",
     "WorkspaceTransferError",
+    "session_create_warnings",
+    "emit_session_create_warnings",
     "DEFAULT_AGENTS_BASE_URL",
     "resolve_agents_base_url",
     "OPENAI_CODEX_ADAPTERS",

--- a/src/pydo/agents/custom_sessions.py
+++ b/src/pydo/agents/custom_sessions.py
@@ -234,6 +234,46 @@ def _verify_transfer_sha256(
 _DROPPED_TENANT_FIELDS = ("tenant_id", "team_id")
 
 
+def session_create_warnings(obj: Any) -> List[str]:
+    """Return create-time advisories from a session object or create response.
+
+    Mirrors godo ``HostedAgentSession.Warnings`` / doctl session-create
+    printing (MARSOHS-1019). Accepts either the create envelope
+    ``{"session": {...}}`` or the inner session object. Populated on create
+    only (manifest + policy fidelity); typically omitted on get/list.
+    """
+    if obj is None:
+        return []
+    get = getattr(obj, "get", None)
+    if get is None:
+        return []
+    inner = get("session")
+    source = inner if inner is not None else obj
+    get_s = getattr(source, "get", None)
+    if get_s is None:
+        return []
+    raw = get_s("warnings")
+    if not raw:
+        return []
+    return [str(item) for item in raw if item]
+
+
+def emit_session_create_warnings(
+    warns: List[str], *, stacklevel: int = 2
+) -> None:
+    """Emit each create-time advisory as a :class:`UserWarning`.
+
+    Used by high-level :meth:`pydo.agents.AgentsResources.start` so callers
+    see the same signals doctl prints on stderr after CreateSession.
+    """
+    for msg in warns:
+        warnings.warn(
+            f"hosted agents session create: {msg}",
+            UserWarning,
+            stacklevel=stacklevel,
+        )
+
+
 def _strip_tenant_fields(obj: Any) -> Any:
     """Recursively remove tenant/team identifiers from a parsed response.
 
@@ -487,6 +527,10 @@ class SessionsOperations:
         :param openai_session_id: Optional OpenAI session id query param.
         :param timeout: HTTP timeout in seconds (defaults to 600 for create —
             sandbox boot can exceed the client-wide 120s default).
+        :returns: Create envelope ``{"session": {...}}``. The session may
+            include ``warnings`` (non-fatal create-time advisories such as
+            policy fidelity / manifest parse notes); see
+            :func:`session_create_warnings`.
         """
         data = _manifest_bytes(manifest)
         params: Optional[Dict[str, Any]] = None
@@ -1121,4 +1165,6 @@ __all__ = [
     "WorkspaceDownload",
     "WorkspaceTransferError",
     "UploadData",
+    "session_create_warnings",
+    "emit_session_create_warnings",
 ]

--- a/src/pydo/agents/session.py
+++ b/src/pydo/agents/session.py
@@ -36,6 +36,7 @@ from .custom_openai_sandbox import (
     send_openai_session_input,
     stream_openai_session_events,
 )
+from .custom_sessions import session_create_warnings
 
 # Normalized event type -> raw SPI ``type`` it maps from.
 _RAW_TO_TYPE = {
@@ -349,6 +350,18 @@ class AgentSession:
         get = getattr(info, "get", None)
         value = get("openai_environment_id") if get else None
         return str(value) if value else None
+
+    @property
+    def warnings(self) -> List[str]:
+        """Create-time advisories from the server (empty when unknown/omitted).
+
+        Populated on the create response only (manifest + policy fidelity);
+        get/list typically omit ``warnings``. See MARSOHS-1019 / godo
+        ``HostedAgentSession.Warnings``.
+        """
+        return session_create_warnings(
+            self.info if self.info is not None else self._raw
+        )
 
     @property
     def is_openai_codex(self) -> bool:

--- a/src/pydo/aio/agents/__init__.py
+++ b/src/pydo/aio/agents/__init__.py
@@ -10,8 +10,10 @@ from typing import Optional
 from pydo.agents import (
     _looks_like_openai_codex_manifest,
     _select_session_by_name,
+    emit_session_create_warnings,
     prepare_openai_codex_manifest,
     resolve_agents_base_url,
+    session_create_warnings,
 )
 from pydo.custom_extensions import _BaseURLProxy
 
@@ -68,6 +70,7 @@ class AsyncAgentsResources:
             resolved,
             openai_session_id=oai_session_id,
         )
+        emit_session_create_warnings(session_create_warnings(resp), stacklevel=2)
         get = getattr(resp, "get", None)
         info = get("session") if get else None
         session_id = (getattr(info or resp, "get", lambda *_: None))("session_id")

--- a/src/pydo/aio/agents/session.py
+++ b/src/pydo/aio/agents/session.py
@@ -15,6 +15,7 @@ from pydo.agents.custom_openai_sandbox import (
     send_openai_session_input,
     stream_openai_session_events,
 )
+from pydo.agents.custom_sessions import session_create_warnings
 from pydo.agents.session import (
     AgentEvent,
     AgentEventType,
@@ -215,6 +216,16 @@ class AsyncAgentSession:
         get = getattr(info, "get", None)
         value = get("openai_environment_id") if get else None
         return str(value) if value else None
+
+    @property
+    def warnings(self) -> List[str]:
+        """Create-time advisories from the server (empty when unknown/omitted).
+
+        See :attr:`pydo.agents.session.AgentSession.warnings`.
+        """
+        return session_create_warnings(
+            self.info if self.info is not None else self._raw
+        )
 
     @property
     def is_openai_codex(self) -> bool:

--- a/tests/agents/test_session_highlevel.py
+++ b/tests/agents/test_session_highlevel.py
@@ -127,7 +127,10 @@ def test_agent_session_warnings_property():
         },
     )
     assert agent.warnings == [warn_msg]
-    assert AgentSession(sessions, "s2", raw={"session": {"session_id": "s2"}}).warnings == []
+    assert (
+        AgentSession(sessions, "s2", raw={"session": {"session_id": "s2"}}).warnings
+        == []
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agents/test_session_highlevel.py
+++ b/tests/agents/test_session_highlevel.py
@@ -112,6 +112,24 @@ def test_agent_event_raw_has_no_tenant_id():
     assert ev.text == "hi"
 
 
+def test_agent_session_warnings_property():
+    warn_msg = 'permissions.rules (tool bash, match.command "*"): inexpressible'
+    sessions = _FakeSessions([])
+    agent = AgentSession(
+        sessions,
+        "s1",
+        raw={
+            "session": {
+                "session_id": "s1",
+                "status": "SESSION_STATUS_READY",
+                "warnings": [warn_msg],
+            }
+        },
+    )
+    assert agent.warnings == [warn_msg]
+    assert AgentSession(sessions, "s2", raw={"session": {"session_id": "s2"}}).warnings == []
+
+
 # ---------------------------------------------------------------------------
 # run / run_streamed
 # ---------------------------------------------------------------------------

--- a/tests/agents/test_sessions.py
+++ b/tests/agents/test_sessions.py
@@ -150,7 +150,7 @@ def test_create_from_manifest_decodes_session_warnings():
     # create-time policy fidelity advisories ride session.warnings.
     warn_msg = (
         'permissions.rules (tool bash, match.command "*"): matcher:prefix '
-        "requires at least one literal token; \"*\" yields zero tokens and "
+        'requires at least one literal token; "*" yields zero tokens and '
         "cannot be rendered as a native prefix rule"
     )
     body = {

--- a/tests/agents/test_sessions.py
+++ b/tests/agents/test_sessions.py
@@ -145,6 +145,70 @@ def test_create_from_manifest_strips_team_id_and_tenant_id():
     assert "tenant_id" not in resp.session
 
 
+def test_create_from_manifest_decodes_session_warnings():
+    # Mirrors godo TestHostedAgentSession_DecodesWarnings (MARSOHS-1019):
+    # create-time policy fidelity advisories ride session.warnings.
+    warn_msg = (
+        'permissions.rules (tool bash, match.command "*"): matcher:prefix '
+        "requires at least one literal token; \"*\" yields zero tokens and "
+        "cannot be rendered as a native prefix rule"
+    )
+    body = {
+        "session": {
+            "session_id": "sess-warn",
+            "status": SessionStatus.READY,
+            "warnings": [warn_msg],
+        }
+    }
+    resources = _make_resources([_FakeResponse(200, body)])
+
+    resp = resources.sessions.create_from_manifest("kind: Agent\n")
+
+    from pydo.agents import session_create_warnings
+
+    assert resp.session.warnings == [warn_msg]
+    assert session_create_warnings(resp) == [warn_msg]
+    assert 'command "*"' in resp.session.warnings[0]
+
+
+def test_create_from_config_decodes_session_warnings():
+    warn_msg = "policy: bare-wildcard bash ask cannot be enforced by Codex CLI"
+    body = {
+        "session": {
+            "session_id": "sess-cfg",
+            "config_id": "cfg-1",
+            "warnings": [warn_msg],
+        }
+    }
+    resources = _make_resources([_FakeResponse(200, body)])
+
+    resp = resources.sessions.create_from_config(name="demo", config_id="cfg-1")
+
+    assert resp.session.warnings == [warn_msg]
+
+
+def test_agents_start_emits_session_create_warnings():
+    warn_msg = (
+        'permissions.rules (tool bash, match.command "*"): matcher:prefix '
+        "requires at least one literal token"
+    )
+    body = {
+        "session": {
+            "session_id": "sess-warn",
+            "status": SessionStatus.READY,
+            "agent_kind": "AGENT_KIND_CODEX_CLI",
+            "warnings": [warn_msg],
+        }
+    }
+    resources = _make_resources([_FakeResponse(200, body)])
+
+    with pytest.warns(UserWarning, match=r'command "\*"'):
+        agent = resources.start("kind: Agent\nmetadata:\n  name: demo\n")
+
+    assert agent.session_id == "sess-warn"
+    assert agent.warnings == [warn_msg]
+
+
 def test_create_from_manifest_preserves_multiline_skill_instructions():
     # spec.skills is forwarded raw, like the rest of the manifest — no client-side
     # parsing/re-marshaling happens, so a multi-line `instructions` block scalar


### PR DESCRIPTION
## Summary

- Decode harness-api create-time `session.warnings` (manifest + policy fidelity) via `session_create_warnings()` and `AgentSession.warnings` / `AsyncAgentSession.warnings`.
- Emit those advisories as `UserWarning` from sync/async `AgentsResources.start`, matching doctl’s post-create stderr print.
- Tests cover low-level create (manifest + config) and high-level `start` / property access.

Pairs with:
- harness-api: https://github.internal.digitalocean.com/digitalocean/cthulhu/pull/173040
- godo: https://github.com/digitalocean/godo/pull/1095
- doctl: https://github.com/digitalocean/doctl/pull/1934

## Test plan

- [x] `PYTHONPATH=src pytest tests/agents/test_sessions.py::test_create_from_manifest_decodes_session_warnings tests/agents/test_sessions.py::test_create_from_config_decodes_session_warnings tests/agents/test_sessions.py::test_agents_start_emits_session_create_warnings tests/agents/test_session_highlevel.py::test_agent_session_warnings_property`
- [x] `PYTHONPATH=src pytest tests/agents/test_sessions.py tests/agents/test_session_highlevel.py` (61 passed)


Made with [Cursor](https://cursor.com)